### PR TITLE
Add run & rollout info

### DIFF
--- a/firehorse/agents/base.py
+++ b/firehorse/agents/base.py
@@ -19,7 +19,7 @@ class TrialContext:
     task_spec: dict
     run_name: str
     split: str
-    task_index: int | None = None
+    task_index: int
     max_turns: int | None = None
     provider_url: str | None = None
     disable_builtin_tools: list[str] = field(default_factory=list)

--- a/firehorse/agents/claude_code.py
+++ b/firehorse/agents/claude_code.py
@@ -17,6 +17,7 @@ from openreward import (
     ToolResult,
     UserMessage,
 )
+from openreward.models import RolloutInfo
 
 from firehorse.agents.base import BaseAgent, AgentResult, TrialContext
 
@@ -308,7 +309,7 @@ class ClaudeCodeAgent(BaseAgent):
         with tempfile.TemporaryDirectory(prefix="orwd-trial-") as tmpdir:
             tmppath = Path(tmpdir)
             result_file = tmppath / "result.json"
-            trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index if ctx.task_index is not None else "unknown"))
+            trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
             log_dir = Path(ctx.output_dir) if ctx.output_dir else None
 
             env_tool_names = [t.name for t in ctx.tools]
@@ -452,7 +453,7 @@ class ClaudeCodeAgent(BaseAgent):
                         environment=ctx.env_name,
                         split=ctx.split,
                         task_spec=ctx.task_spec,
-                        metadata={"model": ctx.model, "agent": "claude-code", "effort": ctx.effort},
+                        metadata={"effort": ctx.effort},
                     )
                     print(f"[claude-code] Rollout: https://openreward.ai/rollout/{main_rollout.event_id}", file=sys.stderr)
                 except Exception as e:
@@ -488,7 +489,10 @@ class ClaudeCodeAgent(BaseAgent):
                 main_log.write(json.dumps(prompt_event) + "\n")
 
             if main_rollout:
-                main_rollout.log(UserMessage(content=full_prompt))
+                main_rollout.log(
+                    UserMessage(content=full_prompt),
+                    rollout_info=RolloutInfo(task_index=ctx.task_index, harness="claude-code"),
+                )
 
             # --- Read stdout and stderr concurrently ---
             turns_used = 0

--- a/firehorse/agents/codex.py
+++ b/firehorse/agents/codex.py
@@ -18,8 +18,10 @@ from openreward import (
     ToolResult,
     UserMessage,
 )
+from openreward.models import RolloutInfo
 
 from firehorse.agents._openrouter_proxy import OpenRouterProxy
+
 from firehorse.agents.base import BaseAgent, AgentResult, TrialContext
 
 # Env tools with these names are always excluded from MCP —
@@ -310,11 +312,7 @@ class CodexAgent(BaseAgent):
         with tempfile.TemporaryDirectory(prefix="orwd-codex-trial-") as tmpdir:
             tmppath = Path(tmpdir)
             result_file = tmppath / "result.json"
-            trial_id = ctx.task_spec.get(
-                "id", ctx.task_spec.get(
-                    "index", ctx.task_index if ctx.task_index is not None else "unknown",
-                ),
-            )
+            trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
             log_dir = Path(ctx.output_dir) if ctx.output_dir else None
 
             env_tool_names = [t.name for t in ctx.tools]
@@ -436,7 +434,7 @@ class CodexAgent(BaseAgent):
                         environment=ctx.env_name,
                         split=ctx.split,
                         task_spec=ctx.task_spec,
-                        metadata={"model": ctx.model, "agent": "codex", "effort": ctx.effort},
+                        metadata={"effort": ctx.effort},
                     )
                     print(
                         f"[codex] Rollout: https://openreward.ai/rollout/{main_rollout.event_id}",
@@ -455,7 +453,10 @@ class CodexAgent(BaseAgent):
                 main_log.write(json.dumps(prompt_event) + "\n")
 
             if main_rollout:
-                main_rollout.log(SystemMessage(content=system_prompt))
+                main_rollout.log(
+                    SystemMessage(content=system_prompt),
+                    rollout_info=RolloutInfo(task_index=ctx.task_index, harness="codex"),
+                )
                 main_rollout.log(UserMessage(content=ctx.prompt_text))
 
             # --- Read stdout and stderr concurrently ---

--- a/firehorse/agents/hermes.py
+++ b/firehorse/agents/hermes.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from openreward import AssistantMessage, ToolCall, ToolResult, UserMessage
 from openreward.api.rollouts.serializers.base import ReasoningItem
+from openreward.models import RolloutInfo
 
 from firehorse.agents.base import BaseAgent, AgentResult, TrialContext
 from firehorse.agents._subprocess_common import (
@@ -96,6 +97,7 @@ def _log_hermes_from_export(
     session_data: dict,
     toolcalls_path: Path,
     rollout: Any,
+    final_info: RolloutInfo | None = None,
 ) -> None:
     """Log structured rollout from a Hermes session export.
 
@@ -175,6 +177,7 @@ def _log_hermes_from_export(
                 ToolResult(content=content_str, call_id=call_id),
                 reward=reward,
                 is_finished=is_finished,
+                rollout_info=final_info if is_finished else None,
             )
 
         elif role == "user":
@@ -185,6 +188,7 @@ def _log_hermes_from_export(
 def _log_hermes_rollout_fallback(
     toolcalls_path: Path,
     rollout: Any,
+    final_info: RolloutInfo | None = None,
 ) -> None:
     """Fallback rollout logging using only the sidecar toolcalls JSONL.
 
@@ -197,6 +201,7 @@ def _log_hermes_rollout_fallback(
     for line in toolcalls_path.read_text().strip().splitlines():
         event = json.loads(line)
         call_id = event.get("call_id", "")
+        is_finished = event.get("finished", False)
         rollout.log(ToolCall(
             name=event.get("tool", ""),
             content=json.dumps(event.get("arguments", {})),
@@ -208,7 +213,8 @@ def _log_hermes_rollout_fallback(
                 call_id=call_id,
             ),
             reward=event.get("reward"),
-            is_finished=event.get("finished", False),
+            is_finished=is_finished,
+            rollout_info=final_info if is_finished else None,
         )
 
 
@@ -239,11 +245,7 @@ class HermesAgent(BaseAgent):
         with tempfile.TemporaryDirectory(prefix="orwd-hermes-trial-") as tmpdir:
             tmppath = Path(tmpdir)
             result_file = tmppath / "result.json"
-            trial_id = ctx.task_spec.get(
-                "id", ctx.task_spec.get(
-                    "index", ctx.task_index if ctx.task_index is not None else "unknown",
-                ),
-            )
+            trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
             log_dir = Path(ctx.output_dir) if ctx.output_dir else None
 
             env_tool_names = [t.name for t in ctx.tools]
@@ -362,7 +364,7 @@ class HermesAgent(BaseAgent):
                         environment=ctx.env_name,
                         split=ctx.split,
                         task_spec=ctx.task_spec,
-                        metadata={"model": ctx.model, "agent": "hermes"},
+                        metadata={},
                     )
                     print(
                         f"[hermes] Rollout: https://openreward.ai/rollout/{main_rollout.event_id}",
@@ -381,7 +383,10 @@ class HermesAgent(BaseAgent):
                 main_log.write(json.dumps(prompt_event) + "\n")
 
             if main_rollout:
-                main_rollout.log(UserMessage(content=full_prompt))
+                main_rollout.log(
+                    UserMessage(content=full_prompt),
+                    rollout_info=RolloutInfo(task_index=ctx.task_index, harness="hermes"),
+                )
 
             # --- Read stdout and stderr concurrently ---
             turns_used = 0
@@ -453,17 +458,21 @@ class HermesAgent(BaseAgent):
             # Export structured session data for rollout logging.
             if main_rollout:
                 session_id = _extract_session_id(stdout_lines)
+                _final_info = RolloutInfo(
+                    task_index=ctx.task_index,
+                    duration_ms=duration_ms,
+                )
                 if session_id:
                     print(f"[hermes] Exporting session {session_id} for rollout", file=sys.stderr)
                     session_data = await _export_hermes_session(session_id, hermes_home)
                     if session_data:
-                        _log_hermes_from_export(session_data, toolcalls_path, main_rollout)
+                        _log_hermes_from_export(session_data, toolcalls_path, main_rollout, final_info=_final_info)
                     else:
                         print("[hermes] Session export failed, falling back to sidecar", file=sys.stderr)
-                        _log_hermes_rollout_fallback(toolcalls_path, main_rollout)
+                        _log_hermes_rollout_fallback(toolcalls_path, main_rollout, final_info=_final_info)
                 else:
                     print("[hermes] No session ID found in stdout, falling back to sidecar", file=sys.stderr)
-                    _log_hermes_rollout_fallback(toolcalls_path, main_rollout)
+                    _log_hermes_rollout_fallback(toolcalls_path, main_rollout, final_info=_final_info)
 
             if main_log:
                 summary_event = {

--- a/firehorse/agents/openclaw.py
+++ b/firehorse/agents/openclaw.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from openreward import AssistantMessage, ToolCall, ToolResult, UserMessage
 from openreward.api.rollouts.serializers.base import ReasoningItem
+from openreward.models import RolloutInfo
 
 from firehorse.agents.base import BaseAgent, AgentResult, TrialContext
 from firehorse.agents._subprocess_common import (
@@ -74,6 +75,7 @@ def _log_openclaw_from_session(
     session_jsonl_path: Path,
     toolcalls_path: Path,
     rollout: Any,
+    final_info: RolloutInfo | None = None,
 ) -> None:
     """Log structured rollout from an OpenClaw session transcript JSONL.
 
@@ -88,7 +90,7 @@ def _log_openclaw_from_session(
     """
     if not session_jsonl_path.exists():
         print(f"[openclaw] Session file not found: {session_jsonl_path}", file=sys.stderr)
-        _log_toolcalls_fallback(toolcalls_path, rollout)
+        _log_toolcalls_fallback(toolcalls_path, rollout, final_info=final_info)
         return
 
     # Build sidecar reward lookup
@@ -181,16 +183,18 @@ def _log_openclaw_from_session(
                 ToolResult(content=content_str, call_id=call_id),
                 reward=reward,
                 is_finished=is_finished,
+                rollout_info=final_info if is_finished else None,
             )
 
 
-def _log_toolcalls_fallback(toolcalls_path: Path, rollout: Any) -> None:
+def _log_toolcalls_fallback(toolcalls_path: Path, rollout: Any, final_info: RolloutInfo | None = None) -> None:
     """Fallback: log only sidecar tool calls when session JSONL is unavailable."""
     if not toolcalls_path.exists():
         return
     for line in toolcalls_path.read_text().strip().splitlines():
         event = json.loads(line)
         call_id = event.get("call_id", "")
+        is_finished = event.get("finished", False)
         rollout.log(ToolCall(
             name=event.get("tool", ""),
             content=json.dumps(event.get("arguments", {})),
@@ -199,7 +203,8 @@ def _log_toolcalls_fallback(toolcalls_path: Path, rollout: Any) -> None:
         rollout.log(
             ToolResult(content=event.get("result", ""), call_id=call_id),
             reward=event.get("reward"),
-            is_finished=event.get("finished", False),
+            is_finished=is_finished,
+            rollout_info=final_info if is_finished else None,
         )
 
 
@@ -229,11 +234,7 @@ class OpenClawAgent(BaseAgent):
         with tempfile.TemporaryDirectory(prefix="orwd-openclaw-trial-") as tmpdir:
             tmppath = Path(tmpdir)
             result_file = tmppath / "result.json"
-            trial_id = ctx.task_spec.get(
-                "id", ctx.task_spec.get(
-                    "index", ctx.task_index if ctx.task_index is not None else "unknown",
-                ),
-            )
+            trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
             log_dir = Path(ctx.output_dir) if ctx.output_dir else None
 
             env_tool_names = [t.name for t in ctx.tools]
@@ -369,7 +370,7 @@ class OpenClawAgent(BaseAgent):
                         environment=ctx.env_name,
                         split=ctx.split,
                         task_spec=ctx.task_spec,
-                        metadata={"model": ctx.model, "agent": "openclaw"},
+                        metadata={},
                     )
                     print(
                         f"[openclaw] Rollout: https://openreward.ai/rollout/{main_rollout.event_id}",
@@ -388,7 +389,10 @@ class OpenClawAgent(BaseAgent):
                 main_log.write(json.dumps(prompt_event) + "\n")
 
             if main_rollout:
-                main_rollout.log(UserMessage(content=full_prompt))
+                main_rollout.log(
+                    UserMessage(content=full_prompt),
+                    rollout_info=RolloutInfo(task_index=ctx.task_index, harness="openclaw"),
+                )
 
             # --- Read stdout and stderr concurrently ---
             # OpenClaw outputs its JSON result to stderr (via runtime.log),
@@ -498,7 +502,11 @@ class OpenClawAgent(BaseAgent):
                     candidates = glob.glob(str(openclaw_dir / "agents" / "*" / "sessions" / f"*orwd*{trial_id}*.jsonl"))
                     if candidates:
                         session_jsonl = Path(candidates[0])
-                _log_openclaw_from_session(session_jsonl, toolcalls_path, main_rollout)
+                _final_info = RolloutInfo(
+                    task_index=ctx.task_index,
+                    duration_ms=duration_ms,
+                )
+                _log_openclaw_from_session(session_jsonl, toolcalls_path, main_rollout, final_info=_final_info)
 
             # Log to JSONL
             if main_log:

--- a/firehorse/agents/react.py
+++ b/firehorse/agents/react.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, IO
 
 from openreward import SystemMessage, UserMessage
+from openreward.models import RolloutInfo
 
 from firehorse.agents.base import BaseAgent, AgentResult, TrialContext
 
@@ -111,7 +112,7 @@ class ReactAgent(BaseAgent):
 
     async def run(self, ctx: TrialContext) -> AgentResult:
         provider, model_name = _parse_provider(ctx.model)
-        trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index if ctx.task_index is not None else "unknown"))
+        trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
         log_dir = Path(ctx.output_dir) if ctx.output_dir else None
         start = time.monotonic()
 
@@ -125,7 +126,7 @@ class ReactAgent(BaseAgent):
                     environment=ctx.env_name,
                     split=ctx.split,
                     task_spec=ctx.task_spec,
-                    metadata={"model": ctx.model, "agent": "react"},
+                    metadata={},
                 )
                 print(
                     f"[react] Rollout: https://openreward.ai/rollout/{rollout.event_id}",
@@ -144,7 +145,10 @@ class ReactAgent(BaseAgent):
         _jsonl_write(log_file, {"type": "user", "content": ctx.prompt_text})
 
         if rollout:
-            rollout.log(SystemMessage(content=SYSTEM_PROMPT))
+            rollout.log(
+                SystemMessage(content=SYSTEM_PROMPT),
+                rollout_info=RolloutInfo(task_index=ctx.task_index, harness="react"),
+            )
             rollout.log(UserMessage(content=ctx.prompt_text))
 
         print(f"[react] Launching with provider={provider} model={model_name}", file=sys.stderr)
@@ -153,13 +157,13 @@ class ReactAgent(BaseAgent):
         result: AgentResult | None = None
         try:
             if provider == "anthropic":
-                result = await self._run_anthropic(ctx, model_name, rollout, log_file)
+                result = await self._run_anthropic(ctx, model_name, rollout, log_file, start)
             elif provider == "openai":
-                result = await self._run_openai(ctx, model_name, rollout, log_file)
+                result = await self._run_openai(ctx, model_name, rollout, log_file, start)
             elif provider == "google":
-                result = await self._run_google(ctx, model_name, rollout, log_file)
+                result = await self._run_google(ctx, model_name, rollout, log_file, start)
             elif provider == "openrouter":
-                result = await self._run_openrouter(ctx, model_name, rollout, log_file)
+                result = await self._run_openrouter(ctx, model_name, rollout, log_file, start)
             else:
                 result = AgentResult(success=False, error=f"Unsupported provider: {provider}")
         except Exception as e:
@@ -229,8 +233,15 @@ class ReactAgent(BaseAgent):
         model_name: str,
         rollout: Any,
         log_file: IO | None,
+        trial_start: float,
     ) -> AgentResult:
         _require(anthropic, "anthropic", "anthropic")
+
+        def _final_info() -> RolloutInfo:
+            return RolloutInfo(
+                task_index=ctx.task_index,
+                duration_ms=int((time.monotonic() - trial_start) * 1000),
+            )
 
         kwargs: dict[str, Any] = {}
         if ctx.provider_url:
@@ -334,7 +345,10 @@ class ReactAgent(BaseAgent):
             user_msg = {"role": "user", "content": tool_result_blocks}
             _jsonl_write(log_file, {"type": "tool_results", "provider": "anthropic", "raw": user_msg})
             if rollout:
-                rollout.log_anthropic_message(user_msg)
+                rollout.log_anthropic_message(
+                    user_msg,
+                    rollout_info=_final_info() if finished else None,
+                )
             messages.append(user_msg)
 
         return AgentResult(
@@ -356,8 +370,15 @@ class ReactAgent(BaseAgent):
         model_name: str,
         rollout: Any,
         log_file: IO | None,
+        trial_start: float,
     ) -> AgentResult:
         _require(AsyncOpenAI, "openai", "openai")
+
+        def _final_info() -> RolloutInfo:
+            return RolloutInfo(
+                task_index=ctx.task_index,
+                duration_ms=int((time.monotonic() - trial_start) * 1000),
+            )
 
         kwargs: dict[str, Any] = {}
         if ctx.provider_url:
@@ -432,7 +453,10 @@ class ReactAgent(BaseAgent):
                         "finished": tr.finished,
                     })
                     if rollout:
-                        rollout.log_openai_response(output_item)
+                        rollout.log_openai_response(
+                            output_item,
+                            rollout_info=_final_info() if finished else None,
+                        )
                 except Exception as e:
                     output_item = {
                         "type": "function_call_output",
@@ -466,10 +490,17 @@ class ReactAgent(BaseAgent):
         model_name: str,
         rollout: Any,
         log_file: IO | None,
+        trial_start: float,
     ) -> AgentResult:
         _require(google_genai, "google-genai", "google")
         genai = google_genai
         types = google_types
+
+        def _final_info() -> RolloutInfo:
+            return RolloutInfo(
+                task_index=ctx.task_index,
+                duration_ms=int((time.monotonic() - trial_start) * 1000),
+            )
 
         client = genai.Client()
         tools_spec = await ctx.session.list_tools(format="google")
@@ -567,7 +598,10 @@ class ReactAgent(BaseAgent):
             tool_content = types.Content(role="user", parts=tool_response_parts)
             _jsonl_write(log_file, {"type": "tool_results", "provider": "google", "raw": str(tool_content)})
             if rollout:
-                rollout.log_gdm_message(tool_content)
+                rollout.log_gdm_message(
+                    tool_content,
+                    rollout_info=_final_info() if finished else None,
+                )
             contents.append(tool_content)
 
         return AgentResult(
@@ -589,8 +623,15 @@ class ReactAgent(BaseAgent):
         model_name: str,
         rollout: Any,
         log_file: IO | None,
+        trial_start: float,
     ) -> AgentResult:
         _require(AsyncOpenAI, "openai", "openrouter")
+
+        def _final_info() -> RolloutInfo:
+            return RolloutInfo(
+                task_index=ctx.task_index,
+                duration_ms=int((time.monotonic() - trial_start) * 1000),
+            )
 
         api_key = os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
         base_url = ctx.provider_url or "https://openrouter.ai/api/v1"
@@ -690,7 +731,10 @@ class ReactAgent(BaseAgent):
                         "finished": tr.finished,
                     })
                     if rollout:
-                        rollout.log_openai_completions(tool_msg)
+                        rollout.log_openai_completions(
+                            tool_msg,
+                            rollout_info=_final_info() if finished else None,
+                        )
                     messages.append(tool_msg)
                 except Exception as e:
                     tool_msg = {

--- a/firehorse/agents/resum/agent.py
+++ b/firehorse/agents/resum/agent.py
@@ -15,6 +15,7 @@ from openreward import (
     ToolResult,
     UserMessage,
 )
+from openreward.models import RolloutInfo
 
 from firehorse.agents.base import AgentResult, BaseAgent, TrialContext
 from firehorse.agents.resum.compaction import CompactionResult, compact_conversation, micro_compact, should_compact_proactively
@@ -93,8 +94,6 @@ class ReSumAgent(BaseAgent):
                     split=ctx.split,
                     task_spec=ctx.task_spec,
                     metadata={
-                        "model": ctx.model,
-                        "agent": "resum",
                         "provider": provider_name,
                         "effort": ctx.effort,
                     },
@@ -112,7 +111,7 @@ class ReSumAgent(BaseAgent):
             "system_prompt": SYSTEM_PROMPT,
             "environment_prompt": ctx.prompt_text,
         })
-        self._log_rollout_system_and_prompt(rollout, SYSTEM_PROMPT, ctx.prompt_text)
+        self._log_rollout_system_and_prompt(rollout, SYSTEM_PROMPT, ctx.prompt_text, ctx.task_index)
 
         # --- Core loop ---
         max_turns = ctx.max_turns
@@ -216,7 +215,14 @@ class ReSumAgent(BaseAgent):
                     if reward is not None:
                         last_reward = reward
 
-                    self._log_tool_result(log_file, rollout, tc.id, output_text, reward, is_finished)
+                    final_info = None
+                    if is_finished:
+                        final_info = RolloutInfo(
+                            task_index=ctx.task_index,
+                            duration_ms=int((time.monotonic() - start_ms) * 1000),
+                            num_compactions=compaction_count,
+                        )
+                    self._log_tool_result(log_file, rollout, tc.id, output_text, reward, is_finished, rollout_info=final_info)
 
                     print(
                         f"[resum]   -> reward={reward} finished={is_finished} "
@@ -366,6 +372,7 @@ class ReSumAgent(BaseAgent):
         output: str,
         reward: float | None,
         finished: bool,
+        rollout_info: RolloutInfo | None = None,
     ) -> None:
         self._log_jsonl(log_file, {
             "type": "tool_result",
@@ -379,6 +386,7 @@ class ReSumAgent(BaseAgent):
                 ToolResult(content=output, call_id=call_id),
                 reward=reward,
                 is_finished=finished,
+                rollout_info=rollout_info,
             )
 
     def _log_compaction(
@@ -444,9 +452,18 @@ class ReSumAgent(BaseAgent):
                     call_id=compact_call_id,
                 ))
 
-    def _log_rollout_system_and_prompt(self, rollout: Any, system_prompt: str, user_prompt: str) -> None:
+    def _log_rollout_system_and_prompt(
+        self,
+        rollout: Any,
+        system_prompt: str,
+        user_prompt: str,
+        task_index: int,
+    ) -> None:
         if rollout:
-            rollout.log(SystemMessage(content=system_prompt))
+            rollout.log(
+                SystemMessage(content=system_prompt),
+                rollout_info=RolloutInfo(task_index=task_index, harness="resum"),
+            )
             rollout.log(UserMessage(content=user_prompt))
 
     def _log_summary(

--- a/firehorse/orchestrator.py
+++ b/firehorse/orchestrator.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.metadata
 import os
 import random
+import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from openreward.client import AsyncOpenReward
+from openreward.models import RunInfo
 from firehorse.agents import get_agent
 from firehorse.agents.claude_code import ENV_TO_BUILTIN
 from firehorse.config import RunConfig, TrialConfig
@@ -48,13 +51,33 @@ def _print_banner(
     print(f"\nStarting trials...\n", file=sys.stderr)
 
 
+def _get_firehorse_version() -> str:
+    try:
+        return importlib.metadata.version("firehorse")
+    except importlib.metadata.PackageNotFoundError:
+        try:
+            return "dev+" + subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=os.path.dirname(__file__),
+                stderr=subprocess.DEVNULL,
+            ).decode().strip()
+        except Exception:
+            return "dev"
+
+
 async def run_evaluation(config: RunConfig) -> RunSummary:
     # Validate provider credentials early
     if config.model.startswith("openrouter/") and not os.environ.get("OPENROUTER_API_KEY"):
         print("Error: OPENROUTER_API_KEY environment variable required for openrouter/ models", file=sys.stderr)
         raise SystemExit(1)
 
-    client = AsyncOpenReward()
+    run_info = RunInfo(
+        model_name=config.model,
+        run_type="eval",
+        framework="firehorse",
+        framework_version=_get_firehorse_version(),
+    )
+    client = AsyncOpenReward(run_info=run_info)
     env = client.environments.get(config.env)
 
     # List tasks


### PR DESCRIPTION
Use run and rollout info instead of metadata.

Model is added to the run info, so only needs to be set when creating the OR client.
Harness goes in rollout info.
