### PR TITLE
Fixed tests using retry's and waits

### DIFF
--- a/tests/test_react.py
+++ b/tests/test_react.py
@@ -357,7 +357,7 @@ class TestRunOpenAI:
         response.output = [func_call]
         response.usage = MagicMock(input_tokens=80, output_tokens=30)
 
-        with patch("openai.AsyncOpenAI") as MockOAI:
+        with patch("firehorse.agents.react.AsyncOpenAI") as MockOAI:
             mock_client = AsyncMock()
             mock_client.responses.create = AsyncMock(return_value=response)
             MockOAI.return_value = mock_client
@@ -384,7 +384,7 @@ class TestRunOpenAI:
         response.output = [text_item]
         response.usage = MagicMock(input_tokens=10, output_tokens=5)
 
-        with patch("openai.AsyncOpenAI") as MockOAI:
+        with patch("firehorse.agents.react.AsyncOpenAI") as MockOAI:
             mock_client = AsyncMock()
             mock_client.responses.create = AsyncMock(return_value=response)
             MockOAI.return_value = mock_client
@@ -434,8 +434,8 @@ class TestRunGoogle:
         mock_response.candidates = [mock_candidate]
         mock_response.usage_metadata = mock_usage
 
-        with patch("google.genai.Client") as MockClient, \
-             patch("google.genai.types") as mock_types:
+        with patch("firehorse.agents.react.google_genai.Client") as MockClient, \
+             patch("firehorse.agents.react.google_types") as mock_types:
             mock_client = MagicMock()
             mock_client.aio.models.generate_content = AsyncMock(return_value=mock_response)
             MockClient.return_value = mock_client
@@ -474,8 +474,8 @@ class TestRunGoogle:
         mock_response.candidates = [mock_candidate]
         mock_response.usage_metadata = MagicMock(prompt_token_count=10, candidates_token_count=5)
 
-        with patch("google.genai.Client") as MockClient, \
-             patch("google.genai.types") as mock_types:
+        with patch("firehorse.agents.react.google_genai.Client") as MockClient, \
+             patch("firehorse.agents.react.google_types") as mock_types:
             mock_client = MagicMock()
             mock_client.aio.models.generate_content = AsyncMock(return_value=mock_response)
             MockClient.return_value = mock_client
@@ -524,7 +524,7 @@ class TestRunOpenRouter:
         mock_response.choices = [mock_choice]
         mock_response.usage = MagicMock(prompt_tokens=70, completion_tokens=20)
 
-        with patch("openai.AsyncOpenAI") as MockOAI:
+        with patch("firehorse.agents.react.AsyncOpenAI") as MockOAI:
             mock_client = AsyncMock()
             mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
             MockOAI.return_value = mock_client
@@ -555,7 +555,7 @@ class TestRunOpenRouter:
         mock_response.choices = [mock_choice]
         mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
 
-        with patch("openai.AsyncOpenAI") as MockOAI:
+        with patch("firehorse.agents.react.AsyncOpenAI") as MockOAI:
             mock_client = AsyncMock()
             mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
             MockOAI.return_value = mock_client
@@ -641,7 +641,7 @@ class TestEdgeCases:
 
         captured_messages: list[dict] = []
 
-        with patch("openai.AsyncOpenAI") as MockOAI:
+        with patch("firehorse.agents.react.AsyncOpenAI") as MockOAI:
             mock_client = AsyncMock()
 
             async def capture_create(**kwargs):
@@ -802,7 +802,7 @@ class TestEdgeCases:
             response.output = [func_call]
             response.usage = MagicMock(input_tokens=80, output_tokens=30)
 
-            with patch("openai.AsyncOpenAI") as MockOAI:
+            with patch("firehorse.agents.react.AsyncOpenAI") as MockOAI:
                 mock_client = AsyncMock()
                 mock_client.responses.create = AsyncMock(return_value=response)
                 MockOAI.return_value = mock_client
@@ -848,7 +848,7 @@ class TestEdgeCases:
             mock_response.choices = [mock_choice]
             mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
 
-            with patch("openai.AsyncOpenAI") as MockOAI:
+            with patch("firehorse.agents.react.AsyncOpenAI") as MockOAI:
                 mock_client = AsyncMock()
                 mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
                 MockOAI.return_value = mock_client
@@ -899,8 +899,8 @@ class TestEdgeCases:
             mock_response.candidates = [mock_candidate]
             mock_response.usage_metadata = mock_usage
 
-            with patch("google.genai.Client") as MockClient, \
-                 patch("google.genai.types") as mock_types:
+            with patch("firehorse.agents.react.google_genai.Client") as MockClient, \
+                 patch("firehorse.agents.react.google_types") as mock_types:
                 mock_client = MagicMock()
                 mock_client.aio.models.generate_content = AsyncMock(return_value=mock_response)
                 MockClient.return_value = mock_client

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -45,7 +45,7 @@ class TestIsMcpFailure:
 
 class TestMcpRetryConstants:
     def test_max_retries(self):
-        assert _MCP_RETRY_MAX == 3
+        assert _MCP_RETRY_MAX == 8
 
     def test_base_delay(self):
         assert _MCP_RETRY_BASE_DELAY == 2.0
@@ -163,12 +163,13 @@ class TestRunTrialRetry:
         config = _make_trial_config()
         task = mock.MagicMock(task_spec={"id": "test-task"})
 
-        with mock.patch("firehorse.trial.asyncio.sleep", new_callable=mock.AsyncMock) as mock_sleep:
+        with mock.patch("firehorse.trial.asyncio.sleep", new_callable=mock.AsyncMock) as mock_sleep, \
+             mock.patch("firehorse.trial.random.uniform", return_value=0.0):
             result = await run_trial(env, task, agent, config)
 
         assert result.success is True
         assert agent.run.call_count == 3
-        # First retry: 2s, second retry: 4s
+        # First retry: 2s, second retry: 4s (with jitter mocked to 0)
         assert mock_sleep.call_count == 2
         mock_sleep.assert_any_call(2.0)
         mock_sleep.assert_any_call(4.0)


### PR DESCRIPTION
`uv run --with pytest --with pytest-asyncio pytest tests/`


```
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/anthonyhartshorn/gr/firehorse_testing/firehorse
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 236 items                                                                                                                                                       

tests/test_builtin_descriptions.py ............................................                                                                                     [ 18%]
tests/test_claude_code.py .............................................                                                                                             [ 37%]
tests/test_codex.py ........................                                                                                                                        [ 47%]
tests/test_convert.py ........                                                                                                                                      [ 51%]
tests/test_react.py ................................                                                                                                                [ 64%]
tests/test_resum.py ...........................................................                                                                                     [ 89%]
tests/test_resum_integration.py ...ssssss.sss                                                                                                                       [ 95%]
tests/test_trial.py ...........                                                                                                                                     [100%]

============================================================================ warnings summary =============================================================================
tests/test_resum_integration.py:33
  /Users/anthonyhartshorn/gr/firehorse_testing/firehorse/tests/test_resum_integration.py:33: PytestUnknownMarkWarning: Unknown pytest.mark.integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    integration = pytest.mark.integration

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 227 passed, 9 skipped, 1 warning in 10.12s ================================================================
```
