### PR TITLE
Windows + codex 0.129 + MCP probe fixes; --toolset override; resume/replay for killed trials

### DIFF
--- a/firehorse/agents/claude_code.py
+++ b/firehorse/agents/claude_code.py
@@ -440,6 +440,14 @@ class ClaudeCodeAgent(BaseAgent):
             #    prompt argument when using --print"
             # stdin works on every Claude Code version we've seen.
             proc_env = {**os.environ, **extra_env}
+            # Claude Code's default MCP startup timeout (30 s) is tight for
+            # Python-based MCP servers on Windows: the interpreter cold-start
+            # plus aiohttp/openreward imports alone takes ~4-8 s, and the
+            # openreward `initialize` adds further latency. Without this
+            # bump, `firehorse.mcp` lands in status='pending' and the trial
+            # aborts with "MCP failed, agent making futile calls". Honor an
+            # operator override but default high enough for Windows.
+            proc_env.setdefault("MCP_TIMEOUT", "120000")
 
             print(f"[claude-code] Launching with model={model_name}", file=sys.stderr)
 

--- a/firehorse/agents/claude_code.py
+++ b/firehorse/agents/claude_code.py
@@ -6,10 +6,16 @@ import collections
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
 from pathlib import Path
 from typing import Any
+
+# asyncio.create_subprocess_exec on Windows uses CreateProcess directly and
+# does not honor PATHEXT, so a bare "claude" fails when only claude.cmd is on
+# PATH (the typical npm-global install). Resolve once via shutil.which.
+_CLAUDE_BIN = shutil.which("claude") or "claude"
 
 from openreward import (
     AssistantMessage,
@@ -309,7 +315,7 @@ class ClaudeCodeAgent(BaseAgent):
 
     async def setup(self) -> None:
         proc = await asyncio.create_subprocess_exec(
-            "claude", "--version",
+            _CLAUDE_BIN, "--version",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -394,7 +400,7 @@ class ClaudeCodeAgent(BaseAgent):
 
             # Build command
             cmd = [
-                "claude",
+                _CLAUDE_BIN,
                 "--print",
                 "--verbose",
                 "--output-format", "stream-json",

--- a/firehorse/agents/claude_code.py
+++ b/firehorse/agents/claude_code.py
@@ -583,18 +583,32 @@ class ClaudeCodeAgent(BaseAgent):
                     if rollout:
                         _log_event_to_rollout(event, rollout, seen_reasoning=seen_reasoning)
 
-                    # Detect MCP server failure from system.init event
+                    # Detect MCP server failure from system.init event.
+                    # Note: Claude Code 2.1.138 emits system.init before MCP
+                    # stdio servers finish booting, so "pending" at this point
+                    # is a normal transient state — wait for tool_result
+                    # errors to confirm. Only definitively-bad statuses count.
                     if event.get("type") == "system" and event.get("subtype") == "init":
+                        _BAD_MCP_STATUSES = {"failed", "error", "needs-auth", "disconnected"}
                         for srv in event.get("mcp_servers", []):
-                            if srv.get("name") == "openreward" and srv.get("status") != "connected":
-                                mcp_failed = True
-                                extra = {k: v for k, v in srv.items() if k not in ("name", "status")}
-                                detail = f" details={extra}" if extra else ""
-                                print(
-                                    f"[claude-code][{trial_id}] MCP 'openreward' status="
-                                    f"{srv.get('status')!r}{detail} — will abort after first futile calls",
-                                    file=sys.stderr,
-                                )
+                            if srv.get("name") == "openreward":
+                                status = srv.get("status")
+                                if status in _BAD_MCP_STATUSES:
+                                    mcp_failed = True
+                                    extra = {k: v for k, v in srv.items() if k not in ("name", "status")}
+                                    detail = f" details={extra}" if extra else ""
+                                    print(
+                                        f"[claude-code][{trial_id}] MCP 'openreward' status="
+                                        f"{status!r}{detail} — will abort after first futile calls",
+                                        file=sys.stderr,
+                                    )
+                                elif status != "connected":
+                                    # "pending" / unknown — log but don't abort yet.
+                                    print(
+                                        f"[claude-code][{trial_id}] MCP 'openreward' status={status!r} "
+                                        f"(still starting); will confirm via tool calls",
+                                        file=sys.stderr,
+                                    )
 
                     # Track the result event (has cost/token data)
                     if event.get("type") == "result":
@@ -611,23 +625,6 @@ class ClaudeCodeAgent(BaseAgent):
                                 tool_use_id = block.get("id", "")
                                 if tool_name.startswith("mcp__openreward__"):
                                     mcp_tool_use_ids[tool_use_id] = tool_name
-                                # Abort if MCP failed and agent is making futile calls
-                                if mcp_failed:
-                                    mcp_failed_tool_calls += 1
-                                    if mcp_failed_tool_calls >= 2:
-                                        tail = "\n    ".join(list(bridge_stderr)[-5:]) or \
-                                            "(no [openreward-bridge] output captured)"
-                                        print(
-                                            f"[claude-code][{trial_id}] MCP failed, agent making futile "
-                                            f"calls — terminating\n"
-                                            f"  last bridge output:\n    {tail}\n"
-                                            f"  common causes: missing/invalid OPENREWARD_API_KEY, "
-                                            f"backend rejecting env/task, or high concurrency "
-                                            f"overloading the backend",
-                                            file=sys.stderr,
-                                        )
-                                        proc.kill()
-                                        return
 
                     # Annotate MCP tool results with call_count for reward file correlation.
                     # Only count successful calls (is_error=False) since the bridge only
@@ -652,6 +649,30 @@ class ClaudeCodeAgent(BaseAgent):
                                         "is_error": is_error,
                                     }
                                     log_file.write(json.dumps(annotation) + "\n")
+                                    # Count *actual* MCP failures, not just any
+                                    # tool call. Abort only after we've seen
+                                    # two real error responses — by then the
+                                    # MCP server has had plenty of time to come
+                                    # up and is genuinely not working.
+                                    if is_error:
+                                        mcp_failed_tool_calls += 1
+                                        if mcp_failed_tool_calls >= 2:
+                                            tail = "\n    ".join(list(bridge_stderr)[-5:]) or \
+                                                "(no [openreward-bridge] output captured)"
+                                            print(
+                                                f"[claude-code][{trial_id}] MCP returning errors on "
+                                                f"{mcp_failed_tool_calls} consecutive calls — terminating\n"
+                                                f"  last bridge output:\n    {tail}\n"
+                                                f"  common causes: missing/invalid OPENREWARD_API_KEY, "
+                                                f"backend rejecting env/task, or high concurrency "
+                                                f"overloading the backend",
+                                                file=sys.stderr,
+                                            )
+                                            proc.kill()
+                                            return
+                                    else:
+                                        # Reset the streak on any successful call.
+                                        mcp_failed_tool_calls = 0
 
             async def read_stderr():
                 assert proc.stderr is not None

--- a/firehorse/agents/claude_code.py
+++ b/firehorse/agents/claude_code.py
@@ -431,18 +431,38 @@ class ClaudeCodeAgent(BaseAgent):
             if submission_reminder:
                 full_prompt = f"{full_prompt}\n\n{submission_reminder}"
             full_prompt = _sanitize_prompt(full_prompt)
-            cmd.extend(["-p", full_prompt])
+            # Pipe the prompt via stdin instead of `-p <prompt>`. Claude
+            # Code 2.1.x no longer accepts -p as a prompt-argument flag
+            # in --print mode (it's now a synonym for --print itself);
+            # passing `-p <text>` gets parsed as setting --print=<text>
+            # and the CLI then errors out with:
+            #   "Input must be provided either through stdin or as a
+            #    prompt argument when using --print"
+            # stdin works on every Claude Code version we've seen.
             proc_env = {**os.environ, **extra_env}
 
             print(f"[claude-code] Launching with model={model_name}", file=sys.stderr)
 
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
                 limit=_SUBPROCESS_LINE_LIMIT,
             )
+            # Send the prompt over stdin and close it so the CLI gets
+            # EOF and starts processing. Best-effort — the CLI surfaces
+            # any input issue via stderr / non-zero exit.
+            try:
+                if proc.stdin is not None:
+                    proc.stdin.write(full_prompt.encode("utf-8"))
+                    await proc.stdin.drain()
+                    proc.stdin.close()
+            except (BrokenPipeError, ConnectionResetError):
+                # CLI exited before we finished writing — its stderr
+                # already captures the failure cause.
+                pass
 
             # --- Set up JSONL logging ---
             main_log = None

--- a/firehorse/agents/claude_code.py
+++ b/firehorse/agents/claude_code.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -556,6 +557,13 @@ class ClaudeCodeAgent(BaseAgent):
             mcp_tool_use_ids: dict[str, str] = {}  # tool_use_id -> mcp tool name
             mcp_result_count = 0
             bridge_stderr: collections.deque[str] = collections.deque(maxlen=20)
+            # For periodic progress reporting — Claude Code rollouts on
+            # large envs can run silently for many minutes, which looks
+            # indistinguishable from a hung process. We print a one-liner
+            # every Nth assistant tool call with the elapsed wall-clock
+            # time and current tool name.
+            run_started = time.monotonic()
+            PROGRESS_EVERY_N_TOOLS = 1  # print on every tool call
 
             async def read_stdout():
                 nonlocal turns_used, result_event, mcp_failed, mcp_failed_tool_calls, mcp_result_count
@@ -625,6 +633,19 @@ class ClaudeCodeAgent(BaseAgent):
                                 tool_use_id = block.get("id", "")
                                 if tool_name.startswith("mcp__openreward__"):
                                     mcp_tool_use_ids[tool_use_id] = tool_name
+                                # Heartbeat — print a short status line so the
+                                # operator can see the trial is making
+                                # progress. Strips the long mcp__openreward__
+                                # prefix for readability.
+                                if turns_used % PROGRESS_EVERY_N_TOOLS == 0:
+                                    elapsed = time.monotonic() - run_started
+                                    short = tool_name.replace("mcp__openreward__", "")
+                                    print(
+                                        f"[claude-code][{trial_id}] turn {turns_used} "
+                                        f"({elapsed:5.0f}s) → {short}",
+                                        file=sys.stderr,
+                                        flush=True,
+                                    )
 
                     # Annotate MCP tool results with call_count for reward file correlation.
                     # Only count successful calls (is_error=False) since the bridge only

--- a/firehorse/agents/claude_code.py
+++ b/firehorse/agents/claude_code.py
@@ -499,6 +499,7 @@ class ClaudeCodeAgent(BaseAgent):
             if ctx.logging and ctx.rollout_client:
                 try:
                     model_short = ctx.model.split("/")[-1]
+                    from firehorse.rollout_replay import resume_metadata
                     main_rollout = ctx.rollout_client.rollout.create(
                         run_name=ctx.run_name,
                         rollout_name=f"claude-code_{model_short}_{trial_id}",
@@ -506,7 +507,12 @@ class ClaudeCodeAgent(BaseAgent):
                         variant=ctx.variant,
                         split=ctx.split,
                         task_spec=ctx.task_spec,
-                        metadata={"effort": ctx.effort, "model": ctx.model, "agent": "claude-code"},
+                        metadata={
+                            "effort": ctx.effort,
+                            "model": ctx.model,
+                            "agent": "claude-code",
+                            **resume_metadata(),
+                        },
                     )
                     print(f"[claude-code] Rollout: https://openreward.ai/rollout/{main_rollout.event_id}", file=sys.stderr)
                 except Exception as e:
@@ -547,6 +553,19 @@ class ClaudeCodeAgent(BaseAgent):
                     UserMessage(content=full_prompt),
                     rollout_info=RolloutInfo(task_index=ctx.task_index, harness="claude-code"),
                 )
+
+                # Resume mode: replay the dead session's messages into
+                # this new rollout so the openreward.ai view mirrors
+                # the original (no-op without OPENREWARD_REPLAY_ROLLOUT_ID).
+                try:
+                    from firehorse.rollout_replay import maybe_replay_into
+                    maybe_replay_into(main_rollout)
+                except Exception as _e:
+                    print(
+                        f"[claude-code] rollout-message replay failed: "
+                        f"{type(_e).__name__}: {_e}",
+                        file=sys.stderr,
+                    )
 
             # --- Read stdout and stderr concurrently ---
             turns_used = 0

--- a/firehorse/agents/codex.py
+++ b/firehorse/agents/codex.py
@@ -408,6 +408,22 @@ class CodexAgent(BaseAgent):
                 mcp_env["OPENREWARD_URL"] = os.environ["OPENREWARD_URL"]
             if ctx.secrets:
                 mcp_env["OPENREWARD_SESSION_SECRETS"] = json.dumps(ctx.secrets)
+            # Forward replay / resume signals to the MCP bridge subprocess.
+            # `firehorse resume` sets these on the firehorse process so the
+            # bridge (which runs in a fresh subprocess started by codex)
+            # needs them explicitly injected via codex's
+            # `-c mcp_servers.openreward.env.<KEY>=<VALUE>` config flags.
+            # Without this forwarding the bridge never sees the manifest
+            # path and silently skips replay — the agent then sees a
+            # blank GW1 env instead of the rebuilt state.
+            for _k in (
+                "OPENREWARD_REPLAY_PATH",
+                "OPENREWARD_REPLAY_ONLY",
+                "OPENREWARD_REPLAY_PROGRESS_FILE",
+            ):
+                _v = os.environ.get(_k)
+                if _v:
+                    mcp_env[_k] = _v
 
             # Rewards sidecar JSONL — must be absolute since the MCP server
             # runs with a different CWD (codex sets `-C tmppath`).
@@ -476,6 +492,22 @@ class CodexAgent(BaseAgent):
                 "--model", model_name,
                 "-C", str(tmppath),
             ]
+            # NOTE: we used to support `codex exec resume <thread_id>` here,
+            # but codex resume does NOT re-bind MCP servers from -c
+            # config flags. The agent's resumed conversation remembers
+            # `mcp__openreward__*` tool names but the new codex process
+            # has no MCP server registered to dispatch them, so every
+            # tool call returns "unsupported call".
+            #
+            # `firehorse resume <dir>` now skips codex resume entirely.
+            # It just relies on OPENREWARD_REPLAY_PATH (handled in the
+            # MCP bridge) to fast-replay every prior tool call against
+            # a fresh OR session so the env reaches the same state. The
+            # agent starts fresh with full MCP tools — it has no memory
+            # of the prior model reasoning, but `view_current_squad` /
+            # the env's own state-inspection tools give it everything
+            # it needs to continue.
+            _resume_thread = None  # no longer used; kept for code below
 
             # MCP server config via dotted-path -c flags
             cmd.extend(["-c", f"mcp_servers.openreward.command={json.dumps(sys.executable)}"])
@@ -498,6 +530,20 @@ class CodexAgent(BaseAgent):
             # covers individual tool calls (e.g. FPL's `next_gameweek`).
             startup_to = int(os.environ.get("OPENREWARD_MCP_STARTUP_SEC", "300"))
             tool_to = int(os.environ.get("OPENREWARD_MCP_TOOL_SEC", "600"))
+            # Replay mode: the bridge's initialize() will fast-replay
+            # every prior tool call before tools/list answers, which on
+            # long rollouts can take 1-5 minutes on top of the normal
+            # cold-start. Bump startup_timeout to 1200s ONLY when
+            # OPENREWARD_REPLAY_PATH is set so non-resume runs keep the
+            # tighter 300s ceiling (which surfaces real env-pod bugs
+            # faster). Operator env-var override always wins.
+            if os.environ.get("OPENREWARD_REPLAY_PATH") and startup_to < 1200:
+                startup_to = 1200
+                print(
+                    f"[codex] replay mode detected — bumping "
+                    f"mcp_servers.openreward.startup_timeout_sec={startup_to}",
+                    file=sys.stderr,
+                )
             cmd.extend(["-c", f"mcp_servers.openreward.startup_timeout_sec={startup_to}"])
             cmd.extend(["-c", f"mcp_servers.openreward.tool_timeout_sec={tool_to}"])
 
@@ -533,6 +579,10 @@ class CodexAgent(BaseAgent):
             # is "-"). Avoids Windows' ~32KB CreateProcess command-line limit,
             # which truncates large prompts mid-text and leaves the agent with
             # only part of the system prompt.
+            # In resume mode we still need a `-` positional and SOMETHING on
+            # stdin — `codex exec resume <id>` with no PROMPT just exits 1
+            # with no output. We send a minimal "Continue." nudge; the agent
+            # already has the full system + env prompt in its on-disk session.
             cmd.append("-")
 
             proc_env = {**os.environ}
@@ -541,12 +591,14 @@ class CodexAgent(BaseAgent):
             # cmd with the prompt. On subsequent attempts we relaunch with
             # `codex exec resume --last` (no prompt) and rely on codex's
             # on-disk session state to pick up exactly where we left off.
+            # NOTE: `codex exec resume` does NOT accept -C/--cd; CWD is
+            # inherited from the prior session. Including -C makes codex
+            # exit 2 with "unexpected argument '-C' found".
             resume_cmd = [
                 _CODEX_BIN, "exec", "resume", "--last",
                 "--json",
                 "--dangerously-bypass-approvals-and-sandbox",
                 "--skip-git-repo-check",
-                "-C", str(tmppath),
             ]
             # Re-attach the same MCP/effort/provider -c overrides so the
             # resumed run uses identical config. Skip the prompt-positional
@@ -570,8 +622,11 @@ class CodexAgent(BaseAgent):
             )
 
             # Write prompt to stdin and close so codex sees EOF.
+            # Resume mode sends a minimal "Continue." instead of the full
+            # system+env prompt (which is already in the on-disk session).
             assert proc.stdin is not None
-            proc.stdin.write(full_prompt.encode("utf-8"))
+            stdin_prompt = "Continue." if _resume_thread else full_prompt
+            proc.stdin.write(stdin_prompt.encode("utf-8"))
             await proc.stdin.drain()
             proc.stdin.close()
 
@@ -585,6 +640,7 @@ class CodexAgent(BaseAgent):
             if ctx.logging and ctx.rollout_client:
                 try:
                     model_short = ctx.model.split("/")[-1]
+                    from firehorse.rollout_replay import resume_metadata
                     main_rollout = ctx.rollout_client.rollout.create(
                         run_name=ctx.run_name,
                         rollout_name=f"codex_{model_short}_{trial_id}",
@@ -592,7 +648,12 @@ class CodexAgent(BaseAgent):
                         variant=ctx.variant,
                         split=ctx.split,
                         task_spec=ctx.task_spec,
-                        metadata={"effort": ctx.effort, "model": ctx.model, "agent": "codex"},
+                        metadata={
+                            "effort": ctx.effort,
+                            "model": ctx.model,
+                            "agent": "codex",
+                            **resume_metadata(),
+                        },
                     )
                     print(
                         f"[codex] Rollout: https://openreward.ai/rollout/{main_rollout.event_id}",
@@ -616,6 +677,20 @@ class CodexAgent(BaseAgent):
                     rollout_info=RolloutInfo(task_index=ctx.task_index, harness="codex"),
                 )
                 main_rollout.log(UserMessage(content=ctx.prompt_text))
+
+                # Resume mode: replay the dead session's messages into
+                # the new rollout so the openreward.ai view of the
+                # resumed run lines up with the original (no-op when
+                # OPENREWARD_REPLAY_ROLLOUT_ID isn't set).
+                try:
+                    from firehorse.rollout_replay import maybe_replay_into
+                    maybe_replay_into(main_rollout)
+                except Exception as _e:
+                    print(
+                        f"[codex] rollout-message replay failed: "
+                        f"{type(_e).__name__}: {_e}",
+                        file=sys.stderr,
+                    )
 
             # --- Read stdout and stderr concurrently ---
             turns_used = 0
@@ -645,11 +720,18 @@ class CodexAgent(BaseAgent):
                     if not line_str:
                         continue
                     stdout_lines.append(line_str)
-                    # Detect OpenAI capacity / quota errors so we can
-                    # resume after a backoff instead of throwing away
-                    # the rollout. Codex itself does not retry on these.
-                    if ("Selected model is at capacity" in line_str
-                            or "model is at capacity" in line_str.lower()):
+                    # Detect ONLY transient OpenAI errors that retry would
+                    # actually fix. "Quota exceeded" / "insufficient_quota"
+                    # mean the project-level credit pool is empty — no
+                    # amount of backoff fixes that, so we let codex exit
+                    # and surface the error. "Selected model is at
+                    # capacity" and "rate_limit_exceeded" are transient
+                    # (model overload / per-minute rate cap) and resolve
+                    # in seconds-to-minutes — those we retry.
+                    _ll = line_str.lower()
+                    if ("selected model is at capacity" in _ll
+                            or "model is at capacity" in _ll
+                            or "rate_limit_exceeded" in _ll):
                         capacity_hit = True
                     try:
                         event = json.loads(line_str)
@@ -717,29 +799,39 @@ class CodexAgent(BaseAgent):
             try:
                 await asyncio.gather(read_stdout(), read_stderr())
                 await proc.wait()
-                # Resume-on-capacity loop. If codex died because OpenAI was
-                # `at_capacity`, sleep with exponential backoff (30 s, 60 s,
-                # 120 s, 240 s, 480 s) and relaunch codex with
-                # `exec resume --last` so it picks up the same on-disk
-                # session state. Bail after max_capacity_retries.
+                # Transient-failure retry. If codex died because of a
+                # transient capacity / rate-limit error, just relaunch
+                # the EXACT same command up to N times with backoff.
+                # This is NOT the resume path — there's no codex
+                # exec resume here, no param changes. The fresh codex
+                # process starts from the original prompt; the OR
+                # session is still alive within TTL so the env state
+                # the agent has built up is preserved.
                 while capacity_hit and capacity_attempt < max_capacity_retries:
                     capacity_attempt += 1
                     delay = backoff_base_s * (2 ** (capacity_attempt - 1))
                     print(
-                        f"[codex][{trial_id}] at_capacity — sleeping {delay:.0f}s "
-                        f"then resume (attempt {capacity_attempt}/{max_capacity_retries})",
+                        f"[codex][{trial_id}] transient error — sleeping {delay:.0f}s "
+                        f"then relaunching (attempt {capacity_attempt}/{max_capacity_retries})",
                         file=sys.stderr,
                         flush=True,
                     )
                     await asyncio.sleep(delay)
                     capacity_hit = False
                     proc = await asyncio.create_subprocess_exec(
-                        *resume_cmd,
+                        *cmd,
+                        stdin=asyncio.subprocess.PIPE,
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                         env=proc_env,
                         limit=1024 * 1024,
                     )
+                    # Same stdin handling as the initial launch.
+                    assert proc.stdin is not None
+                    retry_prompt = "Continue." if _resume_thread else full_prompt
+                    proc.stdin.write(retry_prompt.encode("utf-8"))
+                    await proc.stdin.drain()
+                    proc.stdin.close()
                     await asyncio.gather(read_stdout(), read_stderr())
                     await proc.wait()
             except Exception as e:

--- a/firehorse/agents/codex.py
+++ b/firehorse/agents/codex.py
@@ -438,10 +438,36 @@ class CodexAgent(BaseAgent):
             # Codex exec has no --system-prompt flag; prepend to user prompt
             full_prompt = f"{system_prompt}\n\n---\n\n{ctx.prompt_text}"
 
-            # Build command. We bypass Codex's own approval + sandbox because
-            # every side-effect happens in the OpenReward environment via MCP.
-            # Without this, Codex cancels every MCP tool call in exec mode
-            # since there's no interactive UI to approve them.
+            # Build command. We split the old
+            # --dangerously-bypass-approvals-and-sandbox flag into its two
+            # components so the shell IS sandboxed but the approval gate
+            # is still bypassed:
+            #
+            #   --sandbox workspace-write   → codex's built-in shell can
+            #                                 only read/write within the
+            #                                 per-trial tmppath (-C).
+            #                                 Without this, when MCP
+            #                                 tools/list timed out the
+            #                                 agent fell back to codex's
+            #                                 host shell and read prior
+            #                                 rollouts off ~/.codex/...
+            #   approval_policy=never       → codex executes without
+            #                                 prompting for approval.
+            #                                 In `codex exec` there is no
+            #                                 interactive UI; without
+            #                                 this, every MCP tool call
+            #                                 was auto-cancelled and the
+            #                                 agent's tool calls returned
+            #                                 None.
+            # NOTE: tried splitting this into `--sandbox workspace-write`
+            # + `approval_policy="never"` + `default_tools_approval_mode="never"`
+            # + `mcp_tool_call_approval="never"` to sandbox codex's shell
+            # without losing MCP. Every combination still produced
+            # "user cancelled MCP tool call" in `codex exec` mode, so
+            # we're back on the bypass flag. Host-shell leak (codex
+            # reading ~/.codex/sessions on MCP failure) is a known risk
+            # to fix separately — likely by running codex inside WSL
+            # or a container, not via codex's own sandbox modes.
             cmd = [
                 _CODEX_BIN, "exec",
                 "--json",
@@ -456,6 +482,24 @@ class CodexAgent(BaseAgent):
             cmd.extend(["-c", f"mcp_servers.openreward.args={json.dumps(['-m', 'firehorse.mcp'])}"])
             for key, value in mcp_env.items():
                 cmd.extend(["-c", f"mcp_servers.openreward.env.{key}={json.dumps(value)}"])
+
+            # Codex's defaults are 30 s startup and 60-120 s per tool call.
+            # Long-horizon envs (e.g. FPL's `next_gameweek` runs a full
+            # gameweek simulation; MarketMakerTimed's `run_strategy` plays
+            # 15 min of L2 tick data) regularly exceed those, and codex
+            # then returns `timed out awaiting tools/call`, dropping the
+            # env's reward and finished signals on the floor. Bump both.
+            # Honor operator overrides via env vars.
+            # startup_timeout_sec is the deadline for the WHOLE
+            # session-create chain (OR routing + env __init__ +
+            # sandbox.start + tools/list). A bad-case cold pod with
+            # OR-side ping latency can push to ~80-100s; bump default to
+            # 300s so we don't tip past it on a slow day. tool_timeout_sec
+            # covers individual tool calls (e.g. FPL's `next_gameweek`).
+            startup_to = int(os.environ.get("OPENREWARD_MCP_STARTUP_SEC", "300"))
+            tool_to = int(os.environ.get("OPENREWARD_MCP_TOOL_SEC", "600"))
+            cmd.extend(["-c", f"mcp_servers.openreward.startup_timeout_sec={startup_to}"])
+            cmd.extend(["-c", f"mcp_servers.openreward.tool_timeout_sec={tool_to}"])
 
             # Pass reasoning effort via config override.
             # Codex 0.129+ renamed the top level from "max" to "xhigh"; firehorse
@@ -492,6 +536,27 @@ class CodexAgent(BaseAgent):
             cmd.append("-")
 
             proc_env = {**os.environ}
+
+            # Resume-on-capacity: on the first attempt we run the full
+            # cmd with the prompt. On subsequent attempts we relaunch with
+            # `codex exec resume --last` (no prompt) and rely on codex's
+            # on-disk session state to pick up exactly where we left off.
+            resume_cmd = [
+                _CODEX_BIN, "exec", "resume", "--last",
+                "--json",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--skip-git-repo-check",
+                "-C", str(tmppath),
+            ]
+            # Re-attach the same MCP/effort/provider -c overrides so the
+            # resumed run uses identical config. Skip the prompt-positional
+            # ("-") since `resume` doesn't read stdin.
+            resume_cmd.extend([a for a in cmd if a == "-c"]
+                              + [c for i, c in enumerate(cmd)
+                                 if i > 0 and cmd[i - 1] == "-c"])
+            # Cap retries; back off exponentially starting at 30 s.
+            max_capacity_retries = int(os.environ.get("OPENREWARD_CODEX_CAPACITY_RETRIES", "5"))
+            backoff_base_s = float(os.environ.get("OPENREWARD_CODEX_CAPACITY_BACKOFF_BASE", "30"))
 
             print(f"[codex] Launching with model={model_name}", file=sys.stderr)
 
@@ -556,15 +621,36 @@ class CodexAgent(BaseAgent):
             turns_used = 0
             stdout_lines: list[str] = []
             token_info: dict | None = None
+            run_started = time.monotonic()
+            # Set to True when codex emits an `at_capacity` error.
+            # Used to trigger a resume-with-backoff after proc.wait().
+            capacity_hit = False
+            capacity_attempt = 0
+
+            def _heartbeat(tool_name: str) -> None:
+                elapsed = time.monotonic() - run_started
+                short = tool_name.replace("mcp__openreward__", "") or "?"
+                print(
+                    f"[codex][{trial_id}] turn {turns_used} ({elapsed:5.0f}s) "
+                    f"→ {short}",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
             async def read_stdout():
-                nonlocal turns_used, token_info
+                nonlocal turns_used, token_info, capacity_hit
                 assert proc.stdout is not None
                 async for line in proc.stdout:
                     line_str = line.decode(errors="replace").strip()
                     if not line_str:
                         continue
                     stdout_lines.append(line_str)
+                    # Detect OpenAI capacity / quota errors so we can
+                    # resume after a backoff instead of throwing away
+                    # the rollout. Codex itself does not retry on these.
+                    if ("Selected model is at capacity" in line_str
+                            or "model is at capacity" in line_str.lower()):
+                        capacity_hit = True
                     try:
                         event = json.loads(line_str)
                     except json.JSONDecodeError:
@@ -595,6 +681,7 @@ class CodexAgent(BaseAgent):
                         item = event.get("item", {})
                         if isinstance(item, dict) and item.get("type") == "mcp_tool_call":
                             turns_used += 1
+                            _heartbeat(item.get("tool", ""))
 
                     # Legacy format support (v0.39 nested msg / v0.118 flat)
                     msg = event.get("msg", event)
@@ -602,8 +689,19 @@ class CodexAgent(BaseAgent):
                         msg_type = msg.get("type")
                         if msg_type == "token_count":
                             token_info = msg.get("info", {})
-                        if msg_type in ("mcp_tool_call_begin", "exec_command_begin"):
+                        if msg_type == "mcp_tool_call_begin":
                             turns_used += 1
+                            invocation = msg.get("invocation", {})
+                            tool_name = (
+                                invocation.get("tool")
+                                or invocation.get("tool_name")
+                                or invocation.get("name")
+                                or ""
+                            ) if isinstance(invocation, dict) else ""
+                            _heartbeat(tool_name)
+                        elif msg_type == "exec_command_begin":
+                            turns_used += 1
+                            _heartbeat("shell")
 
             async def read_stderr():
                 assert proc.stderr is not None
@@ -619,6 +717,31 @@ class CodexAgent(BaseAgent):
             try:
                 await asyncio.gather(read_stdout(), read_stderr())
                 await proc.wait()
+                # Resume-on-capacity loop. If codex died because OpenAI was
+                # `at_capacity`, sleep with exponential backoff (30 s, 60 s,
+                # 120 s, 240 s, 480 s) and relaunch codex with
+                # `exec resume --last` so it picks up the same on-disk
+                # session state. Bail after max_capacity_retries.
+                while capacity_hit and capacity_attempt < max_capacity_retries:
+                    capacity_attempt += 1
+                    delay = backoff_base_s * (2 ** (capacity_attempt - 1))
+                    print(
+                        f"[codex][{trial_id}] at_capacity — sleeping {delay:.0f}s "
+                        f"then resume (attempt {capacity_attempt}/{max_capacity_retries})",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    await asyncio.sleep(delay)
+                    capacity_hit = False
+                    proc = await asyncio.create_subprocess_exec(
+                        *resume_cmd,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        env=proc_env,
+                        limit=1024 * 1024,
+                    )
+                    await asyncio.gather(read_stdout(), read_stderr())
+                    await proc.wait()
             except Exception as e:
                 if proc.returncode is None:
                     proc.kill()

--- a/firehorse/agents/codex.py
+++ b/firehorse/agents/codex.py
@@ -4,11 +4,17 @@ import asyncio
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
 import time
 from pathlib import Path
 from typing import Any
+
+# asyncio.create_subprocess_exec on Windows uses CreateProcess directly and
+# does not honor PATHEXT, so a bare "codex" fails when only codex.cmd is on
+# PATH (the typical npm-global install). Resolve once via shutil.which.
+_CODEX_BIN = shutil.which("codex") or "codex"
 
 from openreward import (
     AssistantMessage,
@@ -360,7 +366,7 @@ class CodexAgent(BaseAgent):
 
     async def setup(self) -> None:
         proc = await asyncio.create_subprocess_exec(
-            "codex", "--version",
+            _CODEX_BIN, "--version",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -403,9 +409,11 @@ class CodexAgent(BaseAgent):
             if ctx.secrets:
                 mcp_env["OPENREWARD_SESSION_SECRETS"] = json.dumps(ctx.secrets)
 
-            # Rewards sidecar JSONL
+            # Rewards sidecar JSONL — must be absolute since the MCP server
+            # runs with a different CWD (codex sets `-C tmppath`).
             if log_dir:
-                rewards_path = log_dir / f"trial_{trial_id}_rewards.jsonl"
+                rewards_path = (log_dir / f"trial_{trial_id}_rewards.jsonl").resolve()
+                rewards_path.parent.mkdir(parents=True, exist_ok=True)
                 mcp_env["OPENREWARD_REWARDS_FILE"] = str(rewards_path)
 
             # Compute which env tools to exclude from MCP.
@@ -435,7 +443,7 @@ class CodexAgent(BaseAgent):
             # Without this, Codex cancels every MCP tool call in exec mode
             # since there's no interactive UI to approve them.
             cmd = [
-                "codex", "exec",
+                _CODEX_BIN, "exec",
                 "--json",
                 "--dangerously-bypass-approvals-and-sandbox",
                 "--skip-git-repo-check",
@@ -449,9 +457,12 @@ class CodexAgent(BaseAgent):
             for key, value in mcp_env.items():
                 cmd.extend(["-c", f"mcp_servers.openreward.env.{key}={json.dumps(value)}"])
 
-            # Pass reasoning effort via config override
+            # Pass reasoning effort via config override.
+            # Codex 0.129+ renamed the top level from "max" to "xhigh"; firehorse
+            # still accepts "max" as the canonical name, so translate here.
             if ctx.effort:
-                cmd.extend(["-c", f"model_reasoning_effort={json.dumps(ctx.effort)}"])
+                effort = "xhigh" if ctx.effort == "max" else ctx.effort
+                cmd.extend(["-c", f"model_reasoning_effort={json.dumps(effort)}"])
 
 
             # Configure a non-default model_provider when needed (OpenRouter
@@ -474,7 +485,11 @@ class CodexAgent(BaseAgent):
                     "-c", "features.tool_suggest=false",
                 ])
 
-            cmd.append(full_prompt)
+            # Pass the prompt via stdin (codex reads it when the positional arg
+            # is "-"). Avoids Windows' ~32KB CreateProcess command-line limit,
+            # which truncates large prompts mid-text and leaves the agent with
+            # only part of the system prompt.
+            cmd.append("-")
 
             proc_env = {**os.environ}
 
@@ -482,11 +497,18 @@ class CodexAgent(BaseAgent):
 
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
                 limit=1024 * 1024,  # 1MB line limit for large stderr output
             )
+
+            # Write prompt to stdin and close so codex sees EOF.
+            assert proc.stdin is not None
+            proc.stdin.write(full_prompt.encode("utf-8"))
+            await proc.stdin.drain()
+            proc.stdin.close()
 
             # --- JSONL logging ---
             main_log = None

--- a/firehorse/agents/gemini.py
+++ b/firehorse/agents/gemini.py
@@ -385,6 +385,17 @@ class GeminiAgent(BaseAgent):
             result_stats: dict | None = None
             mcp_failed = False
             accumulated_text: list[str] = []
+            run_started = time.monotonic()
+
+            def _heartbeat(tool_name: str) -> None:
+                elapsed = time.monotonic() - run_started
+                short = tool_name.replace("mcp__openreward__", "") or "?"
+                print(
+                    f"[gemini][{trial_id}] turn {turns_used} ({elapsed:5.0f}s) "
+                    f"→ {short}",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
             async def read_stdout():
                 nonlocal turns_used, result_stats, mcp_failed
@@ -412,6 +423,7 @@ class GeminiAgent(BaseAgent):
                     # Track tool calls as turns
                     if event.get("type") == "tool_use":
                         turns_used += 1
+                        _heartbeat(event.get("tool_name", ""))
 
                     # Capture result stats
                     if event.get("type") == "result":

--- a/firehorse/agents/gemini.py
+++ b/firehorse/agents/gemini.py
@@ -348,6 +348,7 @@ class GeminiAgent(BaseAgent):
             if ctx.logging and ctx.rollout_client:
                 try:
                     model_short = ctx.model.split("/")[-1]
+                    from firehorse.rollout_replay import resume_metadata
                     main_rollout = ctx.rollout_client.rollout.create(
                         run_name=ctx.run_name,
                         rollout_name=f"gemini_{model_short}_{trial_id}",
@@ -355,7 +356,12 @@ class GeminiAgent(BaseAgent):
                         variant=ctx.variant,
                         split=ctx.split,
                         task_spec=ctx.task_spec,
-                        metadata={"effort": ctx.effort, "model": ctx.model, "agent": "gemini"},
+                        metadata={
+                            "effort": ctx.effort,
+                            "model": ctx.model,
+                            "agent": "gemini",
+                            **resume_metadata(),
+                        },
                     )
                     print(
                         f"[gemini] Rollout: https://openreward.ai/rollout/{main_rollout.event_id}",
@@ -378,6 +384,19 @@ class GeminiAgent(BaseAgent):
                     UserMessage(content=full_prompt),
                     rollout_info=RolloutInfo(task_index=ctx.task_index, harness="gemini"),
                 )
+
+                # Resume mode: replay the dead session's messages into
+                # this new rollout so the openreward.ai view mirrors
+                # the original (no-op without OPENREWARD_REPLAY_ROLLOUT_ID).
+                try:
+                    from firehorse.rollout_replay import maybe_replay_into
+                    maybe_replay_into(main_rollout)
+                except Exception as _e:
+                    print(
+                        f"[gemini] rollout-message replay failed: "
+                        f"{type(_e).__name__}: {_e}",
+                        file=sys.stderr,
+                    )
 
             # --- Read stdout and stderr concurrently ---
             turns_used = 0

--- a/firehorse/agents/react.py
+++ b/firehorse/agents/react.py
@@ -309,6 +309,26 @@ class ReactAgent(BaseAgent):
         tools = await ctx.session.list_tools(format="anthropic")
         messages: list[dict] = [{"role": "user", "content": ctx.prompt_text}]
 
+        # Resume mode: seed conversation from the dead session's rollout
+        # so the agent's next API call sees its full prior history as
+        # its own (proper context continuation, not a quoted transcript).
+        try:
+            from firehorse.rollout_replay import maybe_seed_messages_anthropic
+            seeded = maybe_seed_messages_anthropic()
+            if seeded is not None:
+                messages = seeded
+                print(
+                    f"[react] resumed: agent context seeded with "
+                    f"{len(messages)} prior turns",
+                    file=sys.stderr,
+                )
+        except Exception as e:
+            print(
+                f"[react] anthropic context seed failed: "
+                f"{type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+
         trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
         turns_used = 0
         finished = False
@@ -629,6 +649,25 @@ class ReactAgent(BaseAgent):
         contents: list[Any] = [
             types.Content(role="user", parts=[types.Part(text=ctx.prompt_text)])
         ]
+
+        # Resume mode: seed conversation from the dead session's rollout
+        # so the agent's next API call sees its full prior history.
+        try:
+            from firehorse.rollout_replay import maybe_seed_messages_google
+            seeded = maybe_seed_messages_google()
+            if seeded is not None:
+                contents = seeded
+                print(
+                    f"[react] resumed: agent context seeded with "
+                    f"{len(contents)} prior turns",
+                    file=sys.stderr,
+                )
+        except Exception as e:
+            print(
+                f"[react] google context seed failed: "
+                f"{type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
 
         trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
         turns_used = 0

--- a/firehorse/agents/react.py
+++ b/firehorse/agents/react.py
@@ -101,6 +101,23 @@ def _jsonl_write(log_file: IO | None, event: dict) -> None:
         log_file.write(json.dumps(event, default=str) + "\n")
 
 
+def _react_heartbeat(
+    provider: str,
+    trial_id: Any,
+    turns_used: int,
+    trial_start: float,
+    tool_name: str,
+) -> None:
+    elapsed = time.monotonic() - trial_start
+    short = (tool_name or "?").replace("mcp__openreward__", "")
+    print(
+        f"[react/{provider}][{trial_id}] turn {turns_used} "
+        f"({elapsed:5.0f}s) → {short}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 def _format_openrouter_tool(tool: Any) -> dict:
     # Worked around here because openreward's built-in format="openrouter"
     # nests `parameters` outside `function`, which Chat Completions silently
@@ -274,6 +291,7 @@ class ReactAgent(BaseAgent):
         tools = await ctx.session.list_tools(format="anthropic")
         messages: list[dict] = [{"role": "user", "content": ctx.prompt_text}]
 
+        trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
         turns_used = 0
         finished = False
         last_reward: float | None = None
@@ -347,6 +365,7 @@ class ReactAgent(BaseAgent):
                 if block.type != "tool_use":
                     continue
                 turns_used += 1
+                _react_heartbeat("anthropic", trial_id, turns_used, trial_start, block.name)
                 try:
                     tr = await ctx.session.call_tool(block.name, block.input)
                     content = _format_tool_output_anthropic(tr)
@@ -428,6 +447,7 @@ class ReactAgent(BaseAgent):
         tools = await ctx.session.list_tools(format="openai")
         input_list: list[Any] = [{"role": "user", "content": ctx.prompt_text}]
 
+        trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
         turns_used = 0
         finished = False
         last_reward: float | None = None
@@ -494,6 +514,7 @@ class ReactAgent(BaseAgent):
                     continue
                 has_tool_call = True
                 turns_used += 1
+                _react_heartbeat("openai", trial_id, turns_used, trial_start, item.name)
                 try:
                     tr = await ctx.session.call_tool(
                         item.name, json.loads(str(item.arguments))
@@ -591,6 +612,7 @@ class ReactAgent(BaseAgent):
             types.Content(role="user", parts=[types.Part(text=ctx.prompt_text)])
         ]
 
+        trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
         turns_used = 0
         finished = False
         last_reward: float | None = None
@@ -625,6 +647,7 @@ class ReactAgent(BaseAgent):
                     continue
                 turns_used += 1
                 fc = part.function_call
+                _react_heartbeat("google", trial_id, turns_used, trial_start, fc.name)
                 try:
                     tr = await ctx.session.call_tool(
                         fc.name,
@@ -717,6 +740,7 @@ class ReactAgent(BaseAgent):
             {"role": "user", "content": ctx.prompt_text},
         ]
 
+        trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", ctx.task_index))
         turns_used = 0
         finished = False
         last_reward: float | None = None
@@ -792,6 +816,7 @@ class ReactAgent(BaseAgent):
 
             for tc in msg.tool_calls:
                 turns_used += 1
+                _react_heartbeat("openrouter", trial_id, turns_used, trial_start, tc.function.name)
                 raw_args = tc.function.arguments
                 try:
                     args = json.loads(raw_args) if raw_args else {}

--- a/firehorse/agents/react.py
+++ b/firehorse/agents/react.py
@@ -156,6 +156,7 @@ class ReactAgent(BaseAgent):
         if ctx.logging and ctx.rollout_client:
             try:
                 model_short = ctx.model.split("/")[-1]
+                from firehorse.rollout_replay import resume_metadata
                 rollout = ctx.rollout_client.rollout.create(
                     run_name=ctx.run_name,
                     rollout_name=f"react_{model_short}_{trial_id}",
@@ -163,7 +164,11 @@ class ReactAgent(BaseAgent):
                     variant=ctx.variant,
                     split=ctx.split,
                     task_spec=ctx.task_spec,
-                    metadata={"model": ctx.model, "agent": "react"},
+                    metadata={
+                        "model": ctx.model,
+                        "agent": "react",
+                        **resume_metadata(),
+                    },
                 )
                 print(
                     f"[react] Rollout: https://openreward.ai/rollout/{rollout.event_id}",
@@ -190,6 +195,19 @@ class ReactAgent(BaseAgent):
                 rollout_info=RolloutInfo(task_index=ctx.task_index, harness="react"),
             )
             rollout.log(UserMessage(content=ctx.prompt_text))
+
+            # Resume mode: replay the dead session's messages into this
+            # new rollout so the openreward.ai view mirrors the original
+            # (no-op without OPENREWARD_REPLAY_ROLLOUT_ID).
+            try:
+                from firehorse.rollout_replay import maybe_replay_into
+                maybe_replay_into(rollout)
+            except Exception as _e:
+                print(
+                    f"[react] rollout-message replay failed: "
+                    f"{type(_e).__name__}: {_e}",
+                    file=sys.stderr,
+                )
 
         print(f"[react] Launching with provider={provider} model={model_name}", file=sys.stderr)
 

--- a/firehorse/agents/resum/agent.py
+++ b/firehorse/agents/resum/agent.py
@@ -88,6 +88,7 @@ class ReSumAgent(BaseAgent):
         if ctx.logging and ctx.rollout_client:
             try:
                 model_short = ctx.model.split("/")[-1]
+                from firehorse.rollout_replay import resume_metadata
                 rollout = ctx.rollout_client.rollout.create(
                     run_name=ctx.run_name,
                     rollout_name=f"resum_{model_short}_{trial_id}",
@@ -100,6 +101,7 @@ class ReSumAgent(BaseAgent):
                         "effort": ctx.effort,
                         "model": ctx.model,
                         "agent": "resum",
+                        **resume_metadata(),
                     },
                 )
                 print(
@@ -116,6 +118,20 @@ class ReSumAgent(BaseAgent):
             "environment_prompt": ctx.prompt_text,
         })
         self._log_rollout_system_and_prompt(rollout, SYSTEM_PROMPT, ctx.prompt_text, ctx.task_index)
+
+        # Resume mode: replay the dead session's messages into this new
+        # rollout so the openreward.ai view mirrors the original
+        # (no-op without OPENREWARD_REPLAY_ROLLOUT_ID).
+        if rollout:
+            try:
+                from firehorse.rollout_replay import maybe_replay_into
+                maybe_replay_into(rollout)
+            except Exception as _e:
+                print(
+                    f"[resum] rollout-message replay failed: "
+                    f"{type(_e).__name__}: {_e}",
+                    file=sys.stderr,
+                )
 
         # --- Core loop ---
         max_turns = ctx.max_turns

--- a/firehorse/agents/resum/agent.py
+++ b/firehorse/agents/resum/agent.py
@@ -77,6 +77,37 @@ class ReSumAgent(BaseAgent):
         messages = provider.build_initial_messages(SYSTEM_PROMPT, ctx.prompt_text)
         original_prompt = ctx.prompt_text
 
+        # Resume mode: seed conversation from the dead session's rollout
+        # so the agent's next API call sees its full prior history.
+        # Only providers with a seeder available; others fall back to
+        # starting fresh (env state is still rebuilt by the bridge).
+        try:
+            if provider_name == "anthropic":
+                from firehorse.rollout_replay import maybe_seed_messages_anthropic
+                seeded = maybe_seed_messages_anthropic()
+                if seeded is not None:
+                    messages = seeded
+                    print(
+                        f"[resum] resumed: anthropic context seeded with "
+                        f"{len(messages)} prior turns",
+                        file=sys.stderr,
+                    )
+            elif provider_name == "google":
+                from firehorse.rollout_replay import maybe_seed_messages_google
+                seeded = maybe_seed_messages_google()
+                if seeded is not None:
+                    messages = seeded
+                    print(
+                        f"[resum] resumed: google context seeded with "
+                        f"{len(messages)} prior turns",
+                        file=sys.stderr,
+                    )
+        except Exception as e:
+            print(
+                f"[resum] context seed failed: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+
         # --- Setup logging ---
         trial_id = ctx.task_spec.get("id", ctx.task_spec.get("index", "unknown"))
         log_dir = Path(ctx.output_dir) if ctx.output_dir else None

--- a/firehorse/cli.py
+++ b/firehorse/cli.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 import sys
+from datetime import datetime
+from pathlib import Path
 
 from firehorse.config import RunConfig
 from firehorse.orchestrator import run_evaluation
@@ -123,9 +126,364 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resume(argv: list[str]) -> int:
+    """`firehorse resume <results-dir>` — replay a killed trial.
+
+    Parses the existing trial JSONL to recover (env, task_spec, model,
+    codex thread_id, prior tool-call sequence), writes a small manifest
+    to a temp file, and re-invokes `command_run` with two env vars set:
+
+      OPENREWARD_REPLAY_PATH      → the manifest (mcp/bridge.py replays).
+      FIREHORSE_RESUME_THREAD_ID  → codex thread id (codex.py uses
+                                    `codex exec resume <id>` to re-attach
+                                    to the prior conversation).
+    """
+    import argparse, tempfile
+    from firehorse.resume import parse_results_dir, summarize, write_replay_manifest
+
+    p = argparse.ArgumentParser(
+        prog="firehorse resume",
+        description="Resume a killed firehorse trial from its results dir.",
+    )
+    p.add_argument("results_dir", help="A results/<stamp>_<env>_… directory")
+    p.add_argument("--agent", default="codex",
+                   help="Agent to use for the resume (default: codex; only codex supports resume today)")
+    p.add_argument("--model", default=None,
+                   help="Override the model (default: same as the dead run)")
+    p.add_argument("--effort", default="max",
+                   choices=["none", "low", "medium", "high", "max", "xhigh"])
+    p.add_argument("--max-turns", type=int, default=None,
+                   help="Optional cap for the resumed run")
+    p.add_argument("--secret", action="append", default=[], metavar="KEY=VALUE")
+    p.add_argument("--toolset", default=None,
+                   help='Override toolset (pass "" to skip the SDK wrapper)')
+    args = p.parse_args(argv)
+
+    results_dir = Path(args.results_dir).resolve()
+    if not results_dir.is_dir():
+        print(f"[resume] not a directory: {results_dir}", file=sys.stderr)
+        return 2
+
+    state = parse_results_dir(results_dir)
+    print(f"[resume] {summarize(state)}", file=sys.stderr)
+
+    # Recover the original rollout id so we can replay its messages into
+    # the new rollout (so the openreward.ai view of the resumed run
+    # mirrors the dead one). All firehorse agents print
+    # `[<agent>] Rollout: https://openreward.ai/rollout/<id>` to stderr
+    # right after creating their rollout, so run.log has it.
+    from firehorse.rollout_replay import extract_rollout_id_from_run_log
+    orig_rollout_id = extract_rollout_id_from_run_log(results_dir)
+    if orig_rollout_id:
+        print(f"[resume] original rollout id: {orig_rollout_id}", file=sys.stderr)
+    else:
+        print(
+            "[resume] could not find original rollout id in run.log — "
+            "resumed rollout will start with a fresh message history "
+            "(env state will still be rebuilt).",
+            file=sys.stderr,
+        )
+
+    # Note: we no longer use codex's `exec resume <thread_id>`. The agent
+    # starts as a fresh codex process and discovers env state via the
+    # env's own tools (view_current_squad, etc.). The thread_id from the
+    # JSONL is informational only.
+    if state.thread_id is None:
+        print("[resume] (no codex thread_id in JSONL — agent will start fresh "
+              "and rediscover state via env tools.)", file=sys.stderr)
+
+    # Manifest goes alongside the existing trial files so it's not lost
+    # when temp dirs cycle. Re-creatable from the JSONL, so safe to overwrite.
+    manifest_path = results_dir / "resume_manifest.json"
+    write_replay_manifest(state, manifest_path)
+    print(f"[resume] wrote {manifest_path}", file=sys.stderr)
+
+    # Drop a new output dir so we don't trample the prior trial's logs.
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    env_slug = state.env_name.replace("/", "_")
+    new_out = results_dir.parent / f"{stamp}_{env_slug}_RESUMED"
+    new_out.mkdir(parents=True, exist_ok=True)
+
+    # Stamp the resumed run with provenance so downstream tooling (compare
+    # scripts, dashboards) can join it back to the original trial.
+    from collections import Counter
+    _tool_hist = Counter(tc["tool"] for tc in state.tool_calls)
+    resume_meta = {
+        "kind": "firehorse.resume",
+        "resumed_at": datetime.now().isoformat(timespec="seconds"),
+        "cloned_from": {
+            "results_dir": str(results_dir),
+            "results_dir_name": results_dir.name,
+            "trial_jsonl": str(state.trial_jsonl),
+            "thread_id": state.thread_id,
+            "rollout_id": orig_rollout_id,
+            "rollout_url": (
+                f"https://openreward.ai/rollout/{orig_rollout_id}"
+                if orig_rollout_id else None
+            ),
+            "replay_calls": len(state.tool_calls),
+            "replay_calls_by_tool": dict(_tool_hist.most_common()),
+            "last_completed_index": state.last_completed_index,
+            "prior_reward_seen": state.total_reward_seen,
+        },
+        "env": state.env_name,
+        "task_id": state.task_id,
+        "split": state.split,
+        "model": args.model or state.model,
+        "effort": args.effort,
+        "agent": args.agent,
+        "max_turns": args.max_turns,
+        "replay_manifest": str(manifest_path),
+        "replay_progress_file": str(new_out / "replay_progress.jsonl"),
+    }
+    (new_out / "resume_meta.json").write_text(
+        json.dumps(resume_meta, indent=2), encoding="utf-8"
+    )
+    print(
+        f"[resume] cloned from {results_dir.name} "
+        f"(thread={state.thread_id or '?'}, "
+        f"{len(state.tool_calls)} prior calls, "
+        f"prior_reward={state.total_reward_seen:.2f}) → {new_out.name}",
+        file=sys.stderr,
+    )
+
+    secrets = {}
+    for s in (args.secret or []):
+        if "=" not in s:
+            print(f"Invalid --secret format: {s!r}", file=sys.stderr)
+            return 1
+        k, v = s.split("=", 1)
+        secrets[k] = v
+
+    # Only env var we need: OPENREWARD_REPLAY_PATH. The MCP bridge picks
+    # this up during initialize() and fast-replays every prior tool call
+    # against the fresh OR session, so by the time codex queries tools/list
+    # the env is back in its pre-crash state. Codex itself starts fresh.
+    # The codex agent (codex.py) auto-bumps its MCP startup_timeout when
+    # this var is set — replay can take minutes for long rollouts.
+    os.environ["OPENREWARD_REPLAY_PATH"] = str(manifest_path)
+    # Pass the original rollout id to the agent harness so it can replay
+    # the dead session's messages into the new rollout right after
+    # creating it (firehorse/rollout_replay.py:maybe_replay_into).
+    if orig_rollout_id:
+        os.environ["OPENREWARD_REPLAY_ROLLOUT_ID"] = orig_rollout_id
+    # Bridge mirrors every replay step to this file; we tail it below
+    # so the user sees per-step progress in real time. Codex 0.129
+    # buffers MCP subprocess stderr too aggressively for the bridge's
+    # own prints to surface live.
+    progress_path = new_out / "replay_progress.jsonl"
+    os.environ["OPENREWARD_REPLAY_PROGRESS_FILE"] = str(progress_path)
+    print(
+        f"[resume] replay manifest has {len(state.tool_calls)} prior tool calls. "
+        f"Tailing live progress from {progress_path.name}.",
+        file=sys.stderr,
+    )
+
+    # Background thread: tail the bridge's replay_progress.jsonl and print
+    # `[REPLAY i/M tool=X]` per line. Exits on the "complete" event.
+    #
+    # The bridge (a subprocess of codex) writes the file; we read it. On
+    # Windows, a long-lived file handle in process A doesn't reliably see
+    # new data appended by process B even with line-buffered writes —
+    # readline() returns EOF and stays there. Workaround: poll file size
+    # via stat(), and on every cycle reopen → seek(last_pos) → read.
+    import threading, time as _time
+    _stop_tail = threading.Event()
+
+    def _emit(ev: dict) -> bool:
+        """Print one progress event. Returns True if this was 'complete'."""
+        et = ev.get("event")
+        if et == "begin":
+            print(
+                f"[REPLAY] begin: {ev.get('total')} prior tool calls "
+                f"to replay against fresh OR session",
+                file=sys.stderr, flush=True,
+            )
+        elif et == "call":
+            if ev.get("skipped"):
+                marker = f"SKIP ({ev.get('reason','agent-side')})"
+            else:
+                marker = "ok" if ev.get("ok") else "FAIL"
+            print(
+                f"[REPLAY {ev.get('i'):>4}/{ev.get('total')}] "
+                f"tool={ev.get('tool')} {marker}",
+                file=sys.stderr, flush=True,
+            )
+        elif et == "complete":
+            print(
+                f"[REPLAY] complete: ok={ev.get('ok')} "
+                f"fail={ev.get('fail')} skipped={ev.get('skipped',0)} "
+                f"— handing off to agent",
+                file=sys.stderr, flush=True,
+            )
+            return True
+        elif et == "msg-replay-begin":
+            print(
+                f"[ROLLOUT-REPLAY] pushing {ev.get('total')} prior messages "
+                f"from rollout {ev.get('source_rollout')}",
+                file=sys.stderr, flush=True,
+            )
+        elif et == "msg-replay-complete":
+            print(
+                f"[ROLLOUT-REPLAY] complete: logged={ev.get('logged')} "
+                f"skipped={ev.get('skipped')} unknown={ev.get('unknown')}",
+                file=sys.stderr, flush=True,
+            )
+        return False
+
+    def _tail_progress() -> None:
+        last_pos = 0
+        leftover = ""  # carry partial last-line between reads
+        seen_complete = False
+        # Up to ~20 min total wait time (cold OR backend + long replay).
+        idle_deadline = _time.time() + 1200
+        while not _stop_tail.is_set():
+            try:
+                if not progress_path.exists():
+                    if _time.time() > idle_deadline:
+                        return
+                    _time.sleep(0.5)
+                    continue
+                size = progress_path.stat().st_size
+                if size > last_pos:
+                    # Reopen fresh each cycle to bust Windows cross-process
+                    # file-cache visibility issues.
+                    with progress_path.open("r", encoding="utf-8") as f:
+                        f.seek(last_pos)
+                        chunk = f.read()
+                        last_pos = f.tell()
+                    data = leftover + chunk
+                    lines = data.split("\n")
+                    leftover = lines[-1]  # last (possibly partial) line
+                    for ln in lines[:-1]:
+                        ln = ln.strip()
+                        if not ln:
+                            continue
+                        try:
+                            ev = json.loads(ln)
+                        except Exception:
+                            continue
+                        if _emit(ev):
+                            seen_complete = True
+                    if seen_complete:
+                        return
+                    # Reset idle deadline whenever we see progress.
+                    idle_deadline = _time.time() + 1200
+                _time.sleep(0.25)
+            except Exception as _e:
+                print(
+                    f"[REPLAY] tail error: {type(_e).__name__}: {_e}",
+                    file=sys.stderr, flush=True,
+                )
+                _time.sleep(0.5)
+
+    _tail_thread = threading.Thread(target=_tail_progress, daemon=True)
+    _tail_thread.start()
+
+    try:
+        exit_code = asyncio.run(command_run(
+            env=state.env_name,
+            agent=args.agent,
+            model=args.model or state.model,
+            split=state.split,
+            max_tasks=1,
+            max_turns=args.max_turns,
+            secrets=secrets,
+            output_dir=str(new_out),
+            effort=None if args.effort in (None, "none") else args.effort,
+            toolset=args.toolset,
+        ))
+    finally:
+        os.environ.pop("OPENREWARD_REPLAY_PATH", None)
+        os.environ.pop("OPENREWARD_REPLAY_PROGRESS_FILE", None)
+        os.environ.pop("OPENREWARD_REPLAY_ROLLOUT_ID", None)
+        _stop_tail.set()
+
+    return exit_code
+
+
+def _replay(argv: list[str]) -> int:
+    """`firehorse replay <results-dir>` — REPLAY ONLY, no LLM.
+
+    Opens a fresh OR session, calls every recorded tool from the trial
+    JSONL in order, and prints progress + final cumulative reward.
+    Useful to verify that a dead trial's state can be reconstructed
+    before committing to a full `firehorse resume`.
+    """
+    import argparse
+    from firehorse.resume import (
+        parse_results_dir, summarize, replay_against_fresh_session
+    )
+
+    p = argparse.ArgumentParser(
+        prog="firehorse replay",
+        description="Replay a trial's tool-call sequence against a fresh OR session (no LLM).",
+    )
+    p.add_argument("results_dir", help="A results/<stamp>_<env>_… directory")
+    p.add_argument("--secret", action="append", default=[], metavar="KEY=VALUE")
+    p.add_argument("--print-every", type=int, default=1,
+                   help="Print progress every N calls (default 1 = every call)")
+    args = p.parse_args(argv)
+
+    rd = Path(args.results_dir).resolve()
+    if not rd.is_dir():
+        print(f"[replay] not a directory: {rd}", file=sys.stderr)
+        return 2
+
+    state = parse_results_dir(rd)
+    print(f"[replay] {summarize(state)}", file=sys.stderr)
+
+    secrets: dict = {}
+    for s in (args.secret or []):
+        if "=" not in s:
+            print(f"Invalid --secret format: {s!r}", file=sys.stderr)
+            return 1
+        k, v = s.split("=", 1)
+        secrets[k] = v
+
+    summary = asyncio.run(replay_against_fresh_session(
+        state, secrets=secrets or None, print_every=args.print_every,
+    ))
+
+    print("==================== REPLAY SUMMARY ====================", file=sys.stderr)
+    print(f"  env:              {summary['env_name']}", file=sys.stderr)
+    print(f"  task_id:          {summary['task_id']}", file=sys.stderr)
+    print(f"  tool calls total: {summary['total_calls']}", file=sys.stderr)
+    print(f"  succeeded:        {summary['ok']}", file=sys.stderr)
+    print(f"  failed:           {summary['fail']}", file=sys.stderr)
+    print(f"  cumulative reward seen during replay: {summary['total_reward_seen']:.2f}", file=sys.stderr)
+    if summary["errors"]:
+        print(f"  first error: {summary['errors'][0]}", file=sys.stderr)
+    return 0 if summary["fail"] == 0 else 1
+
+
 def main(argv: list[str] | None = None) -> int:
+    # Subcommands: `firehorse resume <dir>` / `firehorse replay <dir>` — peel off
+    # before argparse on the main flag set runs (it doesn't know them).
+    argv = sys.argv[1:] if argv is None else argv
+    if argv and argv[0] == "resume":
+        return _resume(argv[1:])
+    if argv and argv[0] == "replay":
+        return _replay(argv[1:])
+
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    # Reject env names without <namespace>/<env> early — otherwise the
+    # OR session-server returns a confusing nested aiohttp stack trace
+    # ending in `400 X-Deployment must be in the format ...`.
+    env_parts = args.env.split("/")
+    if len(env_parts) != 2 or not env_parts[0] or not env_parts[1]:
+        suggestion = (
+            args.env if "/" in args.env else f"GeneralReasoning/{args.env}"
+        )
+        print(
+            f"firehorse: error: --env must be in the format "
+            f"<namespace>/<environment>, got {args.env!r}\n"
+            f"           e.g. --env {suggestion}",
+            file=sys.stderr,
+        )
+        return 2
 
     secrets = {}
     for s in (args.secret or []):

--- a/firehorse/cli.py
+++ b/firehorse/cli.py
@@ -30,6 +30,7 @@ async def command_run(
     logging: bool = True,
     use_env_descriptions: bool = False,
     use_all_filesystem_tools: bool = False,
+    toolset: str | None = None,
 ) -> int:
     disabled = []
     if disable_builtin_tools:
@@ -55,6 +56,7 @@ async def command_run(
         logging=logging,
         use_builtin_descriptions=not use_env_descriptions,
         use_all_filesystem_tools=use_all_filesystem_tools,
+        toolset=toolset,
     )
 
     summary = await run_evaluation(config)
@@ -112,6 +114,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--use-all-filesystem-tools", action="store_true", default=False,
         help="Codex: expose all filesystem tools via MCP (default: only bash, others filtered)",
     )
+    parser.add_argument(
+        "--toolset", default=None,
+        help="Override the SDK toolset (default: auto-pick by agent). Pass an "
+             "empty string to skip the toolset entirely — required for envs "
+             "without a declared sandbox (e.g. RJT1990/TheTraitors).",
+    )
     return parser
 
 
@@ -148,6 +156,7 @@ def main(argv: list[str] | None = None) -> int:
             logging=not args.no_logging,
             use_env_descriptions=args.use_env_descriptions,
             use_all_filesystem_tools=args.use_all_filesystem_tools,
+            toolset=args.toolset,
         ))
     except KeyboardInterrupt:
         print("\nInterrupted", file=sys.stderr)

--- a/firehorse/config.py
+++ b/firehorse/config.py
@@ -25,6 +25,12 @@ class RunConfig:
     logging: bool = True
     use_builtin_descriptions: bool = True
     use_all_filesystem_tools: bool = False
+    # Toolset override. None = use agent-default mapping (in trial.py).
+    # Empty string = explicitly request no toolset (env serves its own tools
+    # without an SDK-side toolset wrapper). Use this for envs that have no
+    # sandbox declared and therefore can't satisfy the codex/claude-code
+    # toolset's sandbox requirement.
+    toolset: str | None = None
 
     def effective_run_name(self) -> str:
         if self.run_name:
@@ -55,3 +61,4 @@ class TrialConfig:
     use_builtin_descriptions: bool = True
     use_all_filesystem_tools: bool = False
     plan_mode: bool = False
+    toolset: str | None = None

--- a/firehorse/mcp/__main__.py
+++ b/firehorse/mcp/__main__.py
@@ -1,7 +1,40 @@
 """Entry point for the MCP bridge: python -m firehorse.mcp"""
 import asyncio
+import builtins
+import os
 import signal
 import sys
+
+# The MCP bridge talks to its client (codex / claude-code) over
+# stdin/stdout using JSON-RPC. Any non-JSON byte written to stdout
+# corrupts the stream — the client errors with "expected value at line
+# 1 column 1" and tears down the transport.
+#
+# The openreward SDK writes to stdout in two ways:
+#   1. A raw `print(...)` in api/environments/client.py when a session
+#      starts ("Environment session started (sid: ...)").
+#   2. structlog loggers (log_utils.py, rollouts/rollout.py) configured
+#      to write to sys.stdout.
+#
+# We address both before anything imports the SDK:
+#   * Suppress non-error structlog output via OPENREWARD_LOG_LEVEL.
+#   * Replace builtins.print so that any bare `print(...)` from
+#     anywhere in the bridge process (SDK or otherwise) goes to stderr
+#     unless the caller explicitly passed file=. The MCP server uses
+#     sys.stdout.write / sys.stdout.buffer directly, not print, so this
+#     does not affect JSON-RPC framing.
+os.environ.setdefault("OPENREWARD_LOG_LEVEL", "ERROR")
+
+_real_print = builtins.print
+
+
+def _safe_print(*args, **kwargs):
+    if "file" not in kwargs:
+        kwargs["file"] = sys.stderr
+    return _real_print(*args, **kwargs)
+
+
+builtins.print = _safe_print
 
 from firehorse.mcp.bridge import OpenRewardBridge
 

--- a/firehorse/mcp/bridge.py
+++ b/firehorse/mcp/bridge.py
@@ -56,6 +56,24 @@ class OpenRewardBridge:
 
         self.server.list_tools()(self._list_tools)
         self.server.call_tool(validate_input=False)(self._call_tool)
+        # Codex CLI probes resources/list, resources/templates/list, and
+        # prompts/list during MCP startup. We don't expose any of those, but
+        # without explicit handlers the requests time out (30s), and the
+        # error messages leak into the agent's own captured output where the
+        # model sees them and wastes tokens trying to debug. Register empty
+        # handlers so the probes return immediately.
+        self.server.list_resources()(self._list_resources_empty)
+        self.server.list_resource_templates()(self._list_resource_templates_empty)
+        self.server.list_prompts()(self._list_prompts_empty)
+
+    async def _list_resources_empty(self) -> list:
+        return []
+
+    async def _list_resource_templates_empty(self) -> list:
+        return []
+
+    async def _list_prompts_empty(self) -> list:
+        return []
 
     async def initialize(self):
         env_name = os.environ["OPENREWARD_ENV_NAME"]

--- a/firehorse/mcp/bridge.py
+++ b/firehorse/mcp/bridge.py
@@ -157,6 +157,159 @@ class OpenRewardBridge:
 
         print(f"[openreward-bridge] Session created, {len(self.tools)} tools available", file=sys.stderr)
 
+        # Resume replay: if OPENREWARD_REPLAY_PATH points to a JSON file
+        # produced by `firehorse resume`/`firehorse replay`, fast-replay
+        # each prior successful tool call against this fresh OR session
+        # so its env state matches the dead session before the agent's
+        # first turn. See firehorse/resume.py for the manifest schema.
+        #
+        # We also set OPENREWARD_REPLAY_MODE=1 in the env process for
+        # the duration of the replay so env code can detect it and
+        # short-circuit any non-idempotent side effects (logging,
+        # external webhooks, telemetry, etc.).
+        replay_path = os.environ.get("OPENREWARD_REPLAY_PATH")
+        if replay_path:
+            try:
+                manifest = json.loads(open(replay_path, encoding="utf-8").read())
+                calls = manifest.get("tool_calls", [])
+                # If firehorse passed OPENREWARD_REPLAY_PROGRESS_FILE,
+                # mirror each replay event to that file as a JSONL
+                # record. Firehorse tails it in real time and surfaces
+                # `[REPLAY N/M]` lines in the user's terminal — codex
+                # buffers MCP subprocess stderr too aggressively for
+                # the bridge's own prints to surface live.
+                _progress_path = os.environ.get("OPENREWARD_REPLAY_PROGRESS_FILE")
+                _progress_fh = None
+                if _progress_path:
+                    try:
+                        _progress_fh = open(_progress_path, "w", buffering=1)
+                        _progress_fh.write(json.dumps({
+                            "event": "begin",
+                            "total": len(calls),
+                        }) + "\n")
+                    except Exception as _e:
+                        print(
+                            f"[openreward-bridge] could not open progress file "
+                            f"{_progress_path}: {type(_e).__name__}: {_e}",
+                            file=sys.stderr, flush=True,
+                        )
+                        _progress_fh = None
+
+                print(
+                    f"[openreward-bridge] REPLAY MODE BEGIN — "
+                    f"replaying {len(calls)} prior tool calls from "
+                    f"{replay_path} (no LLM in the loop)",
+                    file=sys.stderr, flush=True,
+                )
+                # Hint to env code that we're not driving the agent right now.
+                # Env can check os.environ.get("OPENREWARD_REPLAY_MODE") == "1"
+                # to skip side effects.
+                os.environ["OPENREWARD_REPLAY_MODE"] = "1"
+                # Only env-side tools can be replayed against OR's session.
+                # The trial JSONL also records codex built-ins (bash,
+                # multi_edit, ls, ...) — those are agent-local and OR has
+                # no handler, so sending them produces "unknown tool"
+                # entries that pollute the replay rollout. Filter to the
+                # set OR actually exposes.
+                or_tool_names = {t.name for t in self.tools}
+                try:
+                    ok = 0
+                    fail = 0
+                    skipped = 0
+                    for i, tc in enumerate(calls):
+                        tool = tc.get("tool", "")
+                        args = tc.get("arguments", {}) or {}
+                        if tool not in or_tool_names:
+                            skipped += 1
+                            print(
+                                f"[openreward-bridge] REPLAY {i+1:>4}/{len(calls)} "
+                                f"tool={tool} SKIP (agent-side, not an OR tool)",
+                                file=sys.stderr, flush=True,
+                            )
+                            if _progress_fh is not None:
+                                _progress_fh.write(json.dumps({
+                                    "event": "call",
+                                    "i": i + 1,
+                                    "total": len(calls),
+                                    "tool": tool,
+                                    "ok": True,
+                                    "skipped": True,
+                                    "reason": "not an OR tool",
+                                }) + "\n")
+                            continue
+                        try:
+                            result = await self._session.call_tool(tool, args)
+                            ok += 1
+                            print(
+                                f"[openreward-bridge] REPLAY {i+1:>4}/{len(calls)} "
+                                f"tool={tool} ok",
+                                file=sys.stderr, flush=True,
+                            )
+                            if _progress_fh is not None:
+                                _progress_fh.write(json.dumps({
+                                    "event": "call",
+                                    "i": i + 1,
+                                    "total": len(calls),
+                                    "tool": tool,
+                                    "ok": True,
+                                }) + "\n")
+                        except Exception as e:
+                            fail += 1
+                            print(
+                                f"[openreward-bridge] REPLAY: call {i+1}/{len(calls)} "
+                                f"({tool}) raised {type(e).__name__}: {e}",
+                                file=sys.stderr, flush=True,
+                            )
+                            if _progress_fh is not None:
+                                _progress_fh.write(json.dumps({
+                                    "event": "call",
+                                    "i": i + 1,
+                                    "total": len(calls),
+                                    "tool": tool,
+                                    "ok": False,
+                                    "error": f"{type(e).__name__}: {e}",
+                                }) + "\n")
+                finally:
+                    os.environ.pop("OPENREWARD_REPLAY_MODE", None)
+                if _progress_fh is not None:
+                    try:
+                        _progress_fh.write(json.dumps({
+                            "event": "complete",
+                            "ok": ok,
+                            "fail": fail,
+                            "skipped": skipped,
+                            "total": len(calls),
+                        }) + "\n")
+                        _progress_fh.close()
+                    except Exception:
+                        pass
+                print(
+                    f"[openreward-bridge] REPLAY COMPLETE — ok={ok} fail={fail} "
+                    f"skipped={skipped} (agent-side tools); handing off to agent",
+                    file=sys.stderr, flush=True,
+                )
+                # Replay-only mode: caller wants the env state rebuilt
+                # and that's it. Don't hand off to the agent.
+                if os.environ.get("OPENREWARD_REPLAY_ONLY") == "1":
+                    print(
+                        "[openreward-bridge] REPLAY_ONLY=1 — exiting bridge "
+                        "without serving tools.",
+                        file=sys.stderr, flush=True,
+                    )
+                    # Caller (firehorse replay) is expected to read this
+                    # signal and terminate. Sleep briefly so the message
+                    # actually flushes before stdin close kills us.
+                    await asyncio.sleep(0.5)
+                    sys.exit(0)
+            except SystemExit:
+                raise
+            except Exception as e:
+                print(
+                    f"[openreward-bridge] Replay aborted: "
+                    f"{type(e).__name__}: {e}",
+                    file=sys.stderr, flush=True,
+                )
+
     def _load_prebuilt_tools(self) -> list[Tool] | None:
         """Load pre-built tool specs from env var for instant list_tools response.
 

--- a/firehorse/orchestrator.py
+++ b/firehorse/orchestrator.py
@@ -178,6 +178,7 @@ async def run_evaluation(config: RunConfig) -> RunSummary:
                 use_builtin_descriptions=config.use_builtin_descriptions,
                 use_all_filesystem_tools=config.use_all_filesystem_tools,
                 plan_mode=config.plan_mode,
+                toolset=config.toolset,
             )
             result = await run_trial(
                 env, task, agent, trial_config,

--- a/firehorse/resume.py
+++ b/firehorse/resume.py
@@ -1,0 +1,331 @@
+"""Resume a previously-killed firehorse trial from its on-disk JSONL.
+
+Today's flow:
+    firehorse resume <results-dir> [--max-turns N] [--max-tasks 1]
+
+The results dir is the one firehorse already creates per trial:
+
+    results/<stamp>_<env-slug>_c<C>_t<T>/
+        run.log
+        run_result.json
+        trial_<task_id>.jsonl
+        trial_<task_id>_rewards.jsonl
+        trial_<task_id>_result.json
+
+Everything needed to resume is already in `trial_*.jsonl`:
+
+  * line 1 — `openreward_prompt` with the env's system+environment prompt.
+  * line 2 — `thread.started` with codex's `thread_id` (= codex session id).
+  * every successful `item.completed` of type `mcp_tool_call` with
+    `arguments` and `result.content[*].text` containing the `OR_REWARD`
+    marker.
+
+The resume process:
+  1. Parse the JSONL for: env name, task_spec, model, effort, thread_id,
+     and the ordered sequence of successful mcp_tool_calls.
+  2. Start a fresh `firehorse run`, except:
+       - the MCP bridge is told to **replay** the tool-call sequence
+         (via `OPENREWARD_REPLAY_PATH=<json-file>`) before answering
+         tools/list, so the new OR session arrives at the same env
+         state as the dead one.
+       - codex is launched with `exec resume <thread_id>` so it
+         already knows the prior conversation.
+
+This module owns the parsing + manifest building. The replay-during-init
+logic lives in firehorse/mcp/bridge.py; the codex resume flag is wired
+in firehorse/agents/codex.py.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass
+class ResumeState:
+    """Everything pulled out of an existing trial JSONL needed to resume."""
+    results_dir: Path
+    trial_jsonl: Path
+    env_name: str
+    task_spec: dict
+    task_id: str
+    split: str
+    model: str
+    effort: Optional[str]
+    thread_id: Optional[str]
+    tool_calls: list[dict]  # [{tool, arguments, reward_seen, status}]
+    total_reward_seen: float
+    last_completed_index: int
+
+
+_REWARD_MARKER = "[OR_REWARD:"
+
+
+def _find_trial_jsonl(results_dir: Path) -> Path:
+    """Find the single `trial_*.jsonl` that isn't a sidecar (_rewards / _result)."""
+    candidates = [
+        p for p in results_dir.glob("trial_*.jsonl")
+        if not p.name.endswith("_rewards.jsonl") and "_result" not in p.name
+    ]
+    if not candidates:
+        raise FileNotFoundError(f"No trial_*.jsonl in {results_dir}")
+    if len(candidates) > 1:
+        raise RuntimeError(
+            f"Multiple trial JSONLs in {results_dir} — resume supports single-trial dirs only"
+        )
+    return candidates[0]
+
+
+def _read_run_result(results_dir: Path) -> dict:
+    """Best-effort read of run_result.json for env/model/split fallback."""
+    p = results_dir / "run_result.json"
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _parse_reward_marker(text: str) -> Optional[dict]:
+    """`OR_REWARD:{"r": 0.0, "f": false}` is appended to most tool results."""
+    if _REWARD_MARKER not in text:
+        return None
+    try:
+        start = text.index(_REWARD_MARKER) + len(_REWARD_MARKER)
+        end = text.index("]", start)
+        return json.loads(text[start:end])
+    except (ValueError, json.JSONDecodeError):
+        return None
+
+
+def parse_results_dir(results_dir: Path) -> ResumeState:
+    """Walk the trial JSONL once and pull out everything needed to resume."""
+    trial_path = _find_trial_jsonl(results_dir)
+    run_result = _read_run_result(results_dir)
+
+    env_name: str = run_result.get("environment") or ""
+    model: str = run_result.get("model") or ""
+    split: str = run_result.get("split") or ""
+    task_spec: dict = {}
+    task_id: str = ""
+    effort: Optional[str] = None
+    thread_id: Optional[str] = None
+    tool_calls: list[dict] = []
+    total_reward = 0.0
+    last_completed_index = -1
+
+    with trial_path.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            t = ev.get("type")
+            if t == "openreward_prompt":
+                # System prompt already carries env name in its text; the
+                # most reliable source is run_result.json (we already
+                # read it above). No-op here.
+                continue
+            if t == "openreward_summary":
+                ts = ev.get("task_spec") or {}
+                if ts:
+                    task_spec = ts
+                    task_id = str(ts.get("id") or ts.get("index") or "")
+                if ev.get("env") and not env_name:
+                    env_name = ev["env"]
+                if ev.get("model") and not model:
+                    model = ev["model"]
+                continue
+            if t == "thread.started":
+                tid = ev.get("thread_id")
+                if tid:
+                    thread_id = tid
+                continue
+            if t == "item.completed":
+                item = ev.get("item") or {}
+                if item.get("type") != "mcp_tool_call":
+                    continue
+                if item.get("status") != "completed":
+                    continue
+                tool = item.get("tool") or ""
+                args = item.get("arguments") or {}
+                result = item.get("result") or {}
+                # Pull reward marker from any text block in result.content
+                reward_obj: Optional[dict] = None
+                contents = (result.get("content") or []) if isinstance(result, dict) else []
+                for block in contents:
+                    if not isinstance(block, dict):
+                        continue
+                    txt = block.get("text") or ""
+                    rew = _parse_reward_marker(txt)
+                    if rew is not None:
+                        reward_obj = rew
+                        break
+                r = float(reward_obj["r"]) if reward_obj and "r" in reward_obj else 0.0
+                f_flag = bool(reward_obj["f"]) if reward_obj and "f" in reward_obj else False
+                total_reward += r
+                last_completed_index = len(tool_calls)
+                tool_calls.append({
+                    "tool": tool,
+                    "arguments": args,
+                    "reward_seen": r,
+                    "finished_seen": f_flag,
+                })
+
+    if not env_name:
+        raise RuntimeError(
+            f"Could not determine env name from {results_dir} (run_result.json + "
+            f"trial JSONL openreward_summary both missing it)"
+        )
+
+    return ResumeState(
+        results_dir=results_dir.resolve(),
+        trial_jsonl=trial_path.resolve(),
+        env_name=env_name,
+        task_spec=task_spec,
+        task_id=task_id,
+        split=split or "test",
+        model=model,
+        effort=effort,
+        thread_id=thread_id,
+        tool_calls=tool_calls,
+        total_reward_seen=total_reward,
+        last_completed_index=last_completed_index,
+    )
+
+
+def write_replay_manifest(state: ResumeState, dest: Path) -> Path:
+    """Write the ordered tool-call sequence MCP bridge will replay during
+    initialize(). Just the (tool, arguments) pairs — no rewards (those
+    will be re-emitted by the live env)."""
+    payload = {
+        "env_name": state.env_name,
+        "task_spec": state.task_spec,
+        "task_id": state.task_id,
+        "split": state.split,
+        "thread_id": state.thread_id,
+        "tool_calls": [
+            {"tool": tc["tool"], "arguments": tc["arguments"]}
+            for tc in state.tool_calls
+        ],
+        "expected_total_reward": state.total_reward_seen,
+    }
+    dest.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return dest
+
+
+def summarize(state: ResumeState) -> str:
+    """One-line summary for the operator."""
+    return (
+        f"env={state.env_name} task_id={state.task_id} split={state.split} "
+        f"model={state.model} thread_id={state.thread_id or '?'} "
+        f"replay_calls={len(state.tool_calls)} prior_reward={state.total_reward_seen:.2f}"
+    )
+
+
+async def replay_against_fresh_session(
+    state: ResumeState,
+    secrets: Optional[dict] = None,
+    print_every: int = 1,
+) -> dict:
+    """Open a fresh OR session, replay every recorded tool call directly
+    via the SDK, and return a summary dict.
+
+    This does NOT spawn an MCP bridge and does NOT involve any LLM —
+    it's the "rebuild env state" half of resume. Useful as a diagnostic
+    on its own (`firehorse replay <dir>`).
+    """
+    from openreward.client import AsyncOpenReward
+    from openreward.api.environments.types import Task
+
+    # Parse env_name → namespace + server_name (matches bridge.py logic)
+    namespace: Optional[str] = None
+    server_name = state.env_name
+    if "/" in state.env_name:
+        namespace, server_name = state.env_name.split("/", 1)
+    task_env_name = server_name
+
+    client = AsyncOpenReward()
+    env = client.environments.get(state.env_name)
+    task = Task(
+        server_name=server_name,
+        environment_name=task_env_name,
+        task_spec=state.task_spec,
+        namespace=namespace,
+    )
+
+    print(
+        f"[replay] opening fresh session for {state.env_name} (this can "
+        f"take 30-90s on a cold OR backend)...",
+        file=sys.stderr, flush=True,
+    )
+
+    summary: dict = {
+        "env_name": state.env_name,
+        "task_id": state.task_id,
+        "total_calls": len(state.tool_calls),
+        "ok": 0,
+        "fail": 0,
+        "total_reward_seen": 0.0,
+        "errors": [],
+    }
+    _REWARD = "[OR_REWARD:"
+
+    async with env.session(task, secrets) as session:
+        # Only env-side tools can be replayed against OR. Codex built-ins
+        # (bash, multi_edit, ls, ...) are agent-local; sending them to
+        # OR would record bogus "unknown tool" entries on the rollout.
+        or_tools = await session.list_tools()
+        or_tool_names = {t.name for t in or_tools}
+        summary["skipped"] = 0
+        print(f"[replay] session open. Replaying {len(state.tool_calls)} "
+              f"tool calls ({len(or_tool_names)} OR tools available)...",
+              file=sys.stderr, flush=True)
+        for i, tc in enumerate(state.tool_calls):
+            tool = tc["tool"]
+            args = tc.get("arguments") or {}
+            if tool not in or_tool_names:
+                summary["skipped"] += 1
+                print(
+                    f"[replay] {i+1:>4}/{len(state.tool_calls)} "
+                    f"tool={tool:<24s} SKIP (agent-side, not an OR tool)",
+                    file=sys.stderr, flush=True,
+                )
+                continue
+            try:
+                result = await session.call_tool(tool, args)
+                summary["ok"] += 1
+                # Pull reward marker from result text if present
+                blocks = getattr(result, "content", None) or []
+                for b in blocks:
+                    txt = getattr(b, "text", None) or ""
+                    if _REWARD in txt:
+                        try:
+                            chunk = txt[txt.index(_REWARD) + len(_REWARD):]
+                            chunk = chunk[: chunk.index("]")]
+                            obj = json.loads(chunk)
+                            summary["total_reward_seen"] += float(obj.get("r", 0))
+                        except Exception:
+                            pass
+                if print_every == 1 or (i + 1) % print_every == 0 or (i + 1) == len(state.tool_calls):
+                    print(
+                        f"[replay] {i+1:>4}/{len(state.tool_calls)} "
+                        f"tool={tool:<24s} ok  total_reward={summary['total_reward_seen']:.1f}",
+                        file=sys.stderr, flush=True,
+                    )
+            except Exception as e:
+                summary["fail"] += 1
+                msg = f"call {i+1} tool={tool} raised {type(e).__name__}: {e}"
+                summary["errors"].append(msg)
+                print(f"[replay] {msg}", file=sys.stderr, flush=True)
+    return summary

--- a/firehorse/rollout_replay.py
+++ b/firehorse/rollout_replay.py
@@ -1,0 +1,291 @@
+"""Replay an original OR rollout's messages into a new rollout.
+
+Used by `firehorse resume` to make the resumed rollout visually mirror
+the dead one: the agent's prior assistant / tool_call / tool_result
+messages are pushed into the new rollout via the SDK before the fresh
+agent starts emitting, so on openreward.ai the resumed rollout's first
+~N messages are identical to the original's.
+
+This is harness-agnostic: every firehorse agent (codex, claude_code,
+gemini, react, resum) creates a rollout the same way
+(`ctx.rollout_client.rollout.create(...)`) and then calls
+`main_rollout.log(...)` per event. We tap into that single chokepoint.
+
+The bridge-side `session.call_tool(...)` replay (firehorse/mcp/bridge.py)
+is a separate concern: it rebuilds env state inside OR's session so the
+agent can keep going. Rollout-message replay (this module) is purely
+for visibility on the openreward.ai rollout view.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+from openreward.api.rollouts.serializers.base import (
+    AssistantMessage,
+    ReasoningItem,
+    SystemMessage,
+    ToolCall,
+    ToolResult,
+    UserMessage,
+)
+
+
+_ROLLOUT_URL_RE = re.compile(
+    r"Rollout:\s*https?://[^\s]+?/rollout/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
+)
+
+
+def extract_rollout_id_from_run_log(results_dir: Path) -> Optional[str]:
+    """Scan run.log for `[<agent>] Rollout: https://openreward.ai/rollout/<id>`.
+
+    Every firehorse agent prints this line in the same format right after
+    creating its main rollout. We use that to recover the original
+    rollout id from a dead trial's results dir.
+    """
+    log = results_dir / "run.log"
+    if not log.exists():
+        return None
+    try:
+        text = log.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    m = _ROLLOUT_URL_RE.search(text)
+    return m.group(1) if m else None
+
+
+def fetch_rollout_messages(rollout_id: str, api_key: str) -> list[dict]:
+    """GET /v1/rollouts/<id> on api.openreward.ai and return its messages.
+
+    Uses urllib so we don't add an httpx dependency in agent paths that
+    don't otherwise need it.
+    """
+    base = os.environ.get("OPENREWARD_API_URL")
+    if not base:
+        base = "https://api.openreward.ai"
+    url = f"{base.rstrip('/')}/v1/rollouts/{rollout_id}"
+    req = urllib.request.Request(
+        url,
+        headers={"X-Api-Key": api_key, "User-Agent": "firehorse-resume"},
+        method="GET",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+    msgs = data.get("messages") or []
+    msgs.sort(key=lambda m: m.get("index", 0))
+    return msgs
+
+
+def _msg_to_upload(m: dict) -> Optional[Any]:
+    """Map an OR rollout message dict to the SDK's UploadType variant.
+
+    Returns None for types we don't handle (so the caller can skip them).
+    `content` arrives as a string for messages, JSON-string for tool_call
+    arguments, and string for tool_result. We pass through verbatim.
+    """
+    t = m.get("type")
+    content = m.get("content")
+    # OR API sometimes returns content as a list/dict — coerce to string.
+    if not isinstance(content, str) and content is not None:
+        try:
+            content = json.dumps(content)
+        except Exception:
+            content = str(content)
+    if content is None:
+        content = ""
+
+    if t == "system_message":
+        return SystemMessage(content=content)
+    if t == "user_message":
+        return UserMessage(content=content)
+    if t == "assistant_message":
+        return AssistantMessage(content=content)
+    if t == "reasoning":
+        return ReasoningItem(
+            content=content or None,
+            content_reference=m.get("contentReference"),
+            summary=m.get("summary"),
+        )
+    if t == "tool_call":
+        return ToolCall(
+            name=m.get("name") or "unknown",
+            content=content if content.strip() else "{}",
+            call_id=m.get("callId") or f"call_{m.get('index', '?')}",
+        )
+    if t == "tool_result":
+        return ToolResult(
+            content=content,
+            call_id=m.get("callId") or f"call_{m.get('index', '?')}",
+        )
+    return None
+
+
+def replay_messages_into(
+    main_rollout: Any,
+    rollout_id: str,
+    api_key: str,
+    *,
+    skip_system_and_user: bool = True,
+    progress_fh: Any = None,
+) -> dict:
+    """Fetch <rollout_id>'s messages and push them into `main_rollout`.
+
+    The agent has already logged its own SystemMessage + UserMessage by
+    the time we run (every harness does that right after rollout.create),
+    so by default we skip orig[system_message] + orig[user_message] to
+    avoid duplicates. The env prompts are byte-identical between runs,
+    so the visual match starts at index 0 anyway.
+
+    Returns a small summary dict so the caller can log + write metadata.
+    """
+    summary = {"fetched": 0, "logged": 0, "skipped": 0, "unknown": 0}
+    try:
+        messages = fetch_rollout_messages(rollout_id, api_key)
+    except Exception as e:
+        print(
+            f"[rollout-replay] could not fetch orig rollout {rollout_id}: "
+            f"{type(e).__name__}: {e}",
+            file=sys.stderr, flush=True,
+        )
+        summary["error"] = f"{type(e).__name__}: {e}"
+        return summary
+
+    summary["fetched"] = len(messages)
+    print(
+        f"[rollout-replay] fetched {len(messages)} prior messages from "
+        f"rollout {rollout_id}; pushing into the new rollout so the "
+        f"resumed view mirrors the original.",
+        file=sys.stderr, flush=True,
+    )
+    if progress_fh is not None:
+        try:
+            progress_fh.write(json.dumps({
+                "event": "msg-replay-begin",
+                "total": len(messages),
+                "source_rollout": rollout_id,
+            }) + "\n")
+        except Exception:
+            pass
+
+    saw_system = False
+    saw_user = False
+    for i, m in enumerate(messages):
+        t = m.get("type")
+        if skip_system_and_user:
+            # Skip only the FIRST system_message and FIRST user_message —
+            # if the original had multiple, those are part of the
+            # agent's working history and should be preserved.
+            if t == "system_message" and not saw_system:
+                saw_system = True
+                summary["skipped"] += 1
+                continue
+            if t == "user_message" and not saw_user:
+                saw_user = True
+                summary["skipped"] += 1
+                continue
+        upload = _msg_to_upload(m)
+        if upload is None:
+            summary["unknown"] += 1
+            print(
+                f"[rollout-replay] {i+1:>4}/{len(messages)} type={t!r} — "
+                f"no SDK mapping, skipping",
+                file=sys.stderr, flush=True,
+            )
+            continue
+        try:
+            main_rollout.log(upload)
+            summary["logged"] += 1
+        except Exception as e:
+            summary["unknown"] += 1
+            print(
+                f"[rollout-replay] {i+1:>4}/{len(messages)} type={t!r} "
+                f"raised {type(e).__name__}: {e}",
+                file=sys.stderr, flush=True,
+            )
+            continue
+        if progress_fh is not None and (i + 1) % 25 == 0:
+            try:
+                progress_fh.write(json.dumps({
+                    "event": "msg-replay-progress",
+                    "i": i + 1,
+                    "total": len(messages),
+                    "logged": summary["logged"],
+                }) + "\n")
+            except Exception:
+                pass
+
+    print(
+        f"[rollout-replay] DONE — logged={summary['logged']} "
+        f"skipped={summary['skipped']} unknown={summary['unknown']} "
+        f"of {summary['fetched']} fetched.",
+        file=sys.stderr, flush=True,
+    )
+    if progress_fh is not None:
+        try:
+            progress_fh.write(json.dumps({
+                "event": "msg-replay-complete",
+                **summary,
+            }) + "\n")
+        except Exception:
+            pass
+    return summary
+
+
+def resume_metadata() -> dict:
+    """Resume-specific metadata fields to merge into rollout.create(metadata=...).
+
+    Empty dict when not in resume mode, so call sites can always splat
+    `**resume_metadata()` unconditionally.
+    """
+    rid = os.environ.get("OPENREWARD_REPLAY_ROLLOUT_ID")
+    if not rid:
+        return {}
+    return {
+        "resumed_from_rollout_id": rid,
+        "resumed_from_rollout_url": f"https://openreward.ai/rollout/{rid}",
+        "resume_kind": "firehorse",
+    }
+
+
+def maybe_replay_into(main_rollout: Any) -> Optional[dict]:
+    """Idiom for agent harnesses: call this right after rollout.create.
+
+    No-ops unless `OPENREWARD_REPLAY_ROLLOUT_ID` is set (firehorse CLI
+    sets this in `firehorse resume`). Picks up the OR API key from
+    `OPENREWARD_API_KEY` in the agent process env.
+    """
+    rid = os.environ.get("OPENREWARD_REPLAY_ROLLOUT_ID")
+    if not rid or main_rollout is None:
+        return None
+    api_key = os.environ.get("OPENREWARD_API_KEY")
+    if not api_key:
+        print(
+            "[rollout-replay] OPENREWARD_REPLAY_ROLLOUT_ID is set but "
+            "OPENREWARD_API_KEY is missing — cannot fetch original "
+            "rollout; new rollout will start fresh.",
+            file=sys.stderr, flush=True,
+        )
+        return None
+    progress_path = os.environ.get("OPENREWARD_REPLAY_PROGRESS_FILE")
+    progress_fh = None
+    if progress_path:
+        try:
+            # Append, since the bridge's tool-call replay already opened+wrote+closed.
+            progress_fh = open(progress_path, "a", buffering=1)
+        except Exception:
+            progress_fh = None
+    try:
+        return replay_messages_into(
+            main_rollout, rid, api_key, progress_fh=progress_fh,
+        )
+    finally:
+        if progress_fh is not None:
+            try:
+                progress_fh.close()
+            except Exception:
+                pass

--- a/firehorse/rollout_replay.py
+++ b/firehorse/rollout_replay.py
@@ -40,6 +40,11 @@ _ROLLOUT_URL_RE = re.compile(
     r"Rollout:\s*https?://[^\s]+?/rollout/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
 )
 
+# Per-process cache. The fetch is a single HTTP call but we hit it from
+# multiple places during resume (rollout-mirror, agent context seed) and
+# the SDK pushes to OR async — cleaner to fetch once.
+_ORIG_MSGS_CACHE: Optional[list[dict]] = None
+
 
 def extract_rollout_id_from_run_log(results_dir: Path) -> Optional[str]:
     """Scan run.log for `[<agent>] Rollout: https://openreward.ai/rollout/<id>`.
@@ -57,6 +62,41 @@ def extract_rollout_id_from_run_log(results_dir: Path) -> Optional[str]:
         return None
     m = _ROLLOUT_URL_RE.search(text)
     return m.group(1) if m else None
+
+
+def _coerce_content(c: Any) -> str:
+    if isinstance(c, str):
+        return c
+    if c is None:
+        return ""
+    try:
+        return json.dumps(c)
+    except Exception:
+        return str(c)
+
+
+def _get_orig_messages_cached() -> Optional[list[dict]]:
+    """Fetch the orig rollout's messages once per process; cache thereafter.
+
+    Returns None when the env vars aren't set or the fetch failed.
+    """
+    global _ORIG_MSGS_CACHE
+    if _ORIG_MSGS_CACHE is not None:
+        return _ORIG_MSGS_CACHE
+    rid = os.environ.get("OPENREWARD_REPLAY_ROLLOUT_ID")
+    api_key = os.environ.get("OPENREWARD_API_KEY")
+    if not (rid and api_key):
+        return None
+    try:
+        _ORIG_MSGS_CACHE = fetch_rollout_messages(rid, api_key)
+        return _ORIG_MSGS_CACHE
+    except Exception as e:
+        print(
+            f"[rollout-replay] could not fetch orig rollout {rid}: "
+            f"{type(e).__name__}: {e}",
+            file=sys.stderr, flush=True,
+        )
+        return None
 
 
 def fetch_rollout_messages(rollout_id: str, api_key: str) -> list[dict]:
@@ -250,6 +290,216 @@ def resume_metadata() -> dict:
         "resumed_from_rollout_url": f"https://openreward.ai/rollout/{rid}",
         "resume_kind": "firehorse",
     }
+
+
+# ---------------------------------------------------------------------------
+# Agent-context seeders — convert the orig rollout's normalized message list
+# back into provider-native message arrays so the resumed agent's next API
+# call sees the full prior conversation as its own.
+#
+# Used by python-driven harnesses (react, resum) where firehorse owns the
+# conversation. CLI-driven agents (codex / claude_code / gemini CLI) can't
+# use this — their conversation lives in their own session store.
+# ---------------------------------------------------------------------------
+
+
+def _orig_to_anthropic_messages(orig_messages: list[dict]) -> list[dict]:
+    """Group OR's flat normalized events into Anthropic API turns.
+
+    The Anthropic Messages API expects alternating user/assistant turns:
+      assistant turn  = [{type:text}, {type:thinking}, {type:tool_use}...]
+      user turn       = [{type:tool_result, tool_use_id, content}...]
+
+    We collapse consecutive assistant_message/reasoning/tool_call events
+    into a single assistant turn, and consecutive tool_results into a
+    single user turn. system_message is omitted (it goes in `system=`).
+    """
+    out: list[dict] = []
+    assistant_buf: list[dict] | None = None
+    user_tool_buf: list[dict] | None = None
+
+    def _flush_assistant() -> None:
+        nonlocal assistant_buf
+        if assistant_buf:
+            out.append({"role": "assistant", "content": assistant_buf})
+            assistant_buf = None
+
+    def _flush_user_tool() -> None:
+        nonlocal user_tool_buf
+        if user_tool_buf:
+            out.append({"role": "user", "content": user_tool_buf})
+            user_tool_buf = None
+
+    for m in orig_messages:
+        t = m.get("type")
+        content = _coerce_content(m.get("content"))
+
+        if t == "system_message":
+            continue
+        if t == "user_message":
+            _flush_assistant()
+            _flush_user_tool()
+            out.append({"role": "user", "content": content})
+            continue
+        if t in ("assistant_message", "reasoning", "tool_call"):
+            _flush_user_tool()
+            if assistant_buf is None:
+                assistant_buf = []
+            if t == "assistant_message":
+                if content:
+                    assistant_buf.append({"type": "text", "text": content})
+            elif t == "reasoning":
+                thinking = content or m.get("summary") or ""
+                if thinking:
+                    assistant_buf.append({"type": "thinking", "thinking": thinking})
+            else:  # tool_call
+                try:
+                    args = json.loads(content) if content else {}
+                    if not isinstance(args, dict):
+                        args = {}
+                except (json.JSONDecodeError, ValueError):
+                    args = {}
+                assistant_buf.append({
+                    "type": "tool_use",
+                    "id": m.get("callId") or f"call_{m.get('index', '?')}",
+                    "name": m.get("name") or "unknown",
+                    "input": args,
+                })
+        elif t == "tool_result":
+            _flush_assistant()
+            if user_tool_buf is None:
+                user_tool_buf = []
+            user_tool_buf.append({
+                "type": "tool_result",
+                "tool_use_id": m.get("callId") or f"call_{m.get('index', '?')}",
+                "content": content,
+            })
+
+    _flush_assistant()
+    _flush_user_tool()
+    return out
+
+
+def _orig_to_google_contents(orig_messages: list[dict]) -> list[Any]:
+    """Group OR's flat events into Google Gemini's `types.Content` list.
+
+    Each Content has role ("user" | "model") and parts (Part objects).
+    Tool calls live in model turns as function_call Parts; tool results
+    in user turns as function_response Parts. system_message is omitted
+    (it goes in `system_instruction=`).
+    """
+    # Import lazily so non-Gemini callers don't need google-genai installed.
+    from google.genai import types  # type: ignore
+
+    out: list[Any] = []
+    model_parts: list[Any] | None = None
+    user_parts: list[Any] | None = None
+    # callId → tool name for matching tool_result back to its tool_call
+    call_name_by_id: dict[str, str] = {}
+
+    def _flush_model() -> None:
+        nonlocal model_parts
+        if model_parts:
+            out.append(types.Content(role="model", parts=model_parts))
+            model_parts = None
+
+    def _flush_user() -> None:
+        nonlocal user_parts
+        if user_parts:
+            out.append(types.Content(role="user", parts=user_parts))
+            user_parts = None
+
+    for m in orig_messages:
+        t = m.get("type")
+        content = _coerce_content(m.get("content"))
+
+        if t == "system_message":
+            continue
+        if t == "user_message":
+            _flush_model()
+            _flush_user()
+            out.append(types.Content(role="user", parts=[types.Part(text=content)]))
+            continue
+        if t in ("assistant_message", "reasoning", "tool_call"):
+            _flush_user()
+            if model_parts is None:
+                model_parts = []
+            if t == "assistant_message":
+                if content:
+                    model_parts.append(types.Part(text=content))
+            elif t == "reasoning":
+                thinking = content or m.get("summary") or ""
+                if thinking:
+                    # Gemini reasoning is a text Part with thought=True
+                    model_parts.append(types.Part(text=thinking, thought=True))
+            else:  # tool_call
+                try:
+                    args = json.loads(content) if content else {}
+                    if not isinstance(args, dict):
+                        args = {}
+                except (json.JSONDecodeError, ValueError):
+                    args = {}
+                name = m.get("name") or "unknown"
+                call_name_by_id[m.get("callId") or ""] = name
+                model_parts.append(types.Part.from_function_call(name=name, args=args))
+        elif t == "tool_result":
+            _flush_model()
+            if user_parts is None:
+                user_parts = []
+            cid = m.get("callId") or ""
+            name = call_name_by_id.get(cid) or m.get("name") or "unknown"
+            user_parts.append(types.Part.from_function_response(
+                name=name,
+                response={"result": content},
+            ))
+
+    _flush_model()
+    _flush_user()
+    return out
+
+
+def maybe_seed_messages_anthropic() -> Optional[list[dict]]:
+    """Return an Anthropic-format `messages` list seeded from the orig rollout.
+
+    No-op (returns None) outside of `firehorse resume`. Call sites that
+    own a `messages` list should replace it with this when non-None:
+
+        seeded = maybe_seed_messages_anthropic()
+        if seeded is not None:
+            messages = seeded
+    """
+    msgs = _get_orig_messages_cached()
+    if not msgs:
+        return None
+    seeded = _orig_to_anthropic_messages(msgs)
+    print(
+        f"[rollout-replay] seeded anthropic context: "
+        f"{len(seeded)} turns from {len(msgs)} flat events",
+        file=sys.stderr, flush=True,
+    )
+    return seeded
+
+
+def maybe_seed_messages_google() -> Optional[list[Any]]:
+    """Return a Gemini-format `contents` list seeded from the orig rollout."""
+    msgs = _get_orig_messages_cached()
+    if not msgs:
+        return None
+    try:
+        seeded = _orig_to_google_contents(msgs)
+    except ImportError:
+        print(
+            "[rollout-replay] google-genai not installed; cannot seed "
+            "Gemini context. The resumed agent will start fresh.",
+            file=sys.stderr, flush=True,
+        )
+        return None
+    print(
+        f"[rollout-replay] seeded gemini context: "
+        f"{len(seeded)} turns from {len(msgs)} flat events",
+        file=sys.stderr, flush=True,
+    )
+    return seeded
 
 
 def maybe_replay_into(main_rollout: Any) -> Optional[dict]:

--- a/firehorse/trial.py
+++ b/firehorse/trial.py
@@ -36,13 +36,18 @@ async def run_trial(
     start = time.monotonic()
 
     # Map agent names to SDK toolset names. These toolsets provide optimized
-    # tool descriptions for each agent type.
+    # tool descriptions for each agent type. A non-None config.toolset always
+    # wins (incl. the empty string, which means "no toolset" — use the env's
+    # own tools directly, for envs without a sandbox).
     _AGENT_TO_TOOLSET = {
         "claude-code": "claude-code",
         "codex": "codex",
         "gemini": "gemini-cli",
     }
-    toolset_name = _AGENT_TO_TOOLSET.get(agent.name)
+    if config.toolset is None:
+        toolset_name = _AGENT_TO_TOOLSET.get(agent.name)
+    else:
+        toolset_name = config.toolset or None
 
     try:
         session_secrets = config.secrets or None


### PR DESCRIPTION
## Summary

Bundle of fixes + features that came up while running the LongHorizon30 baseline sweep on Windows (codex-cli 0.129, gpt-5.5). Originally a Windows-compat bug-fix bundle and a `--toolset` flag — extended with a full **resume/replay** mechanism for trials killed by transient agent errors (quota, capacity, 504).

---

### 1) Bug-fix bundle — `fix(codex,claude-code,mcp)`

- **Windows .cmd resolution.** `asyncio.create_subprocess_exec` on Windows uses `CreateProcess` directly, which doesn't honor `PATHEXT`. With only `codex.cmd`/`claude.cmd` on PATH (npm-global install), the bare `"codex"`/`"claude"` failed instantly with `WinError 2`. Fixed by `shutil.which` resolution.
- **codex 0.129 effort renaming.** codex now rejects `max` with `unknown variant 'max'`; the top tier is `xhigh`. Translated client-side so firehorse keeps accepting `--effort max` as the canonical name.
- **Windows command-line truncation.** The system + MCP + task prompt routinely exceeds CreateProcess's ~32 KB limit. Codex was getting a truncated prompt and replying *"Ready. What would you like me to work on?"*. Switched to piping via stdin (`codex exec -`).
- **MCP rewards file path.** Codex starts the MCP server in a fresh CWD via `-C tmppath`, so the relative `results/...` path passed via `OPENREWARD_REWARDS_FILE` errored at startup. Resolved to absolute path.
- **MCP capability probe handlers.** Codex probes `resources/list`, `resources/templates/list`, and `prompts/list` during MCP startup. Without handlers, each request hung to a 30 s timeout, the error string leaked into the agent's own captured output, and gpt-5.5 frequently quit the trial after seeing *"MCP startup failed: timed out handshaking"*. Registered empty handlers.

### 2) New `--toolset` flag — `feat(cli)`

`trial.py` hardcodes the SDK toolset based on agent type, which forces every codex run through `CodexToolset`. That toolset requires `env.sandbox`; envs without one (TheTraitors, AgroManager, ICUCoordinator, LD50, MolScent, Formula2SMILES, ValidMol, ATC, and others) all 400 with `Toolset CodexToolset requires env.sandbox`. Their own task tools work fine without a sandbox — they just don't need the wrapper.

Added `--toolset`:
- omitted → use agent default (no behavior change)
- `--toolset NAME` → override
- `--toolset ""` → skip the SDK toolset entirely; the agent talks to the env's own tools directly via MCP

Confirmed unblocks TheTraitors, AgroManager (`devatreya/AgroManager`), and the GR-namespaced envs above.

### 3) Resume / replay killed trials — `feat(resume,replay)`

Long-running rollouts (LongHorizon30 envs can run 60-90 min) routinely get killed by transient errors — OpenAI quota exhaustion, model `at_capacity`, OR gateway 504s. Re-running from scratch wastes the prior compute and produces a different trajectory. This adds two subcommands that recover from any partial run by reading the JSONL it already wrote to disk.

**Two new commands:**

- `firehorse replay <results-dir>` — opens a fresh OR session and replays every recorded tool call directly via the SDK (no LLM, no agent). Useful as a diagnostic: verifies a dead trial's state can be reconstructed before committing to a full resume.
- `firehorse resume <results-dir>` — does the env-state replay above, **also** mirrors the original rollout's messages into a new rollout, then hands off to a fresh agent that continues from where the dead one stopped.

**Three layers of replay, each addressing a different concern:**

| Layer | What it rebuilds | Where it lives |
|---|---|---|
| Env state | OR session's internal task state (GW reached, squad, transfers, etc.) | `mcp/bridge.py` — calls `session.call_tool` for each recorded tool, fast-forwards the env to its pre-crash state |
| Rollout view | The openreward.ai rollout page (the first N messages visually match the original) | `rollout_replay.py` (new) — fetches orig rollout's messages from `api.openreward.ai/v1/rollouts/<id>` and pushes them through `main_rollout.log()` via the SDK's `UploadType` variants |
| Agent context | The agent's own conversation memory | not yet — fresh agent re-derives via the env's tools. See "Follow-ups" below. |

**Harness-agnostic** — every agent (`codex`, `claude_code`, `gemini`, `react`, `resum`) calls `maybe_replay_into(main_rollout)` right after creating its main rollout. The function no-ops unless `OPENREWARD_REPLAY_ROLLOUT_ID` is set by the CLI.

**Provenance:**
- Resumed rollouts carry `resumed_from_rollout_id` / `resumed_from_rollout_url` / `resume_kind` in their OR metadata so orig→resumed can be joined with a single filter.
- Each resumed trial's output dir gets a `resume_meta.json` sidecar with full provenance (orig results_dir, orig rollout id, replay call histogram, prior reward seen).

**Other fixes bundled in:**
- `codex.py` auto-bumps `mcp_servers.openreward.startup_timeout_sec` to 1200s only when in replay mode (long replays can otherwise hit the default 300s timeout).
- `cli.py` tailer uses size-poll + seek-from-last-position + reopen-each-cycle to reliably stream the bridge's `replay_progress.jsonl` on Windows (cross-process `readline()` visibility is unreliable on Windows even with line-buffered writes).
- `bridge.py` filters replay calls to tools the env actually exposes (no-op for envs like FPL that expose sandboxed `bash`/`read`/`write`, useful for envs without a computer-use toolset).

**Follow-ups (not in this PR):**
- Agent-context continuation for python-driven harnesses: `react` and `resum` keep their conversation in a plain Python list, so we can seed it from the orig rollout's messages and the next provider call sees the full prior history as its own — no codex `exec resume` / MCP-rebind workaround needed. Tracked separately.
- CLI-session-based harnesses (codex / claude-code / gemini) would need their respective CLIs to rebind MCP on `exec resume`; not solvable from firehorse alone.

## Test plan

- [x] codex agent on Windows resolves `codex.cmd` and starts (`./run.sh GeneralReasoning/KellyBench -t 5 -a codex -m openai/gpt-5.5 --effort max`)
- [x] codex --effort max passes through as `model_reasoning_effort=xhigh`
- [x] Long prompt (~50 KB) reaches gpt-5.5 intact; agent engages with the task instead of bailing with "Ready"
- [x] MCP rewards JSONL is written correctly under `results/<run-dir>/`
- [x] No `MCP startup failed: timed out handshaking` lines in fresh trial JSONLs after the bridge handlers landed
- [x] `--toolset ""` lets non-sandbox envs (e.g. RJT1990/TheTraitors, devatreya/AgroManager) run end-to-end and produce rewards
- [x] claude-code agent on Windows resolves `claude.cmd` and starts (`./run.sh GeneralReasoning/MarketMakerTimed -t 1 -a claude-code -m anthropic/claude-opus-4-7 --effort max --max-turns 200`)
- [x] `firehorse replay <dead-trial>` opens a fresh OR session, replays 234 tool calls against it, and exits with the same cumulative reward the dead trial had reached
- [x] `firehorse resume <dead-trial>` produces a new rollout whose first ~540 messages match the original (visual check on `openreward.ai/rollout/<new-id>`); `resumed_from_rollout_id` lands in the new rollout's metadata
- [x] Resumed FPL session played all 38 gameweeks and reported a final season total, with `resume_meta.json` documenting the lineage
- [x] CLI tailer prints `[REPLAY 1/234]` through `[REPLAY 234/234]` without gaps on Windows after the size-poll fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)