### PR TITLE
Reconcile tool-error handling with SDK typed errors + session poisoning

### DIFF
--- a/firehorse/agents/react.py
+++ b/firehorse/agents/react.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, IO
 
 from openreward import SystemMessage, UserMessage
+from openreward.api.errors import SessionTerminatedError, ToolFailed
 from openreward.models import RolloutInfo
 
 from firehorse.agents.base import BaseAgent, AgentResult, TrialContext
@@ -430,6 +431,11 @@ class ReactAgent(BaseAgent):
                         "content": content,
                     })
                 except Exception as e:
+                    # A poisoned/terminated session can't recover — end the
+                    # trajectory cleanly rather than spamming dead-session
+                    # errors for the rest of the turn budget (SDK #1780).
+                    if isinstance(e, (SessionTerminatedError, ToolFailed)):
+                        raise
                     tool_result_blocks.append({
                         "type": "tool_result",
                         "tool_use_id": block.id,
@@ -584,6 +590,8 @@ class ReactAgent(BaseAgent):
                             rollout_info=_final_info() if finished else None,
                         )
                 except Exception as e:
+                    if isinstance(e, (SessionTerminatedError, ToolFailed)):
+                        raise
                     output_item = {
                         "type": "function_call_output",
                         "call_id": item.call_id,
@@ -733,6 +741,8 @@ class ReactAgent(BaseAgent):
                         )
                     )
                 except Exception as e:
+                    if isinstance(e, (SessionTerminatedError, ToolFailed)):
+                        raise
                     tool_response_parts.append(
                         types.Part.from_function_response(
                             name=fc.name,
@@ -908,6 +918,8 @@ class ReactAgent(BaseAgent):
                         )
                     messages.append(tool_msg)
                 except Exception as e:
+                    if isinstance(e, (SessionTerminatedError, ToolFailed)):
+                        raise
                     tool_msg = {
                         "role": "tool",
                         "tool_call_id": tc.id,

--- a/firehorse/agents/resum/agent.py
+++ b/firehorse/agents/resum/agent.py
@@ -15,6 +15,7 @@ from openreward import (
     ToolResult,
     UserMessage,
 )
+from openreward.api.errors import SessionTerminatedError, ToolFailed
 from openreward.models import RolloutInfo
 
 from firehorse.agents.base import AgentResult, BaseAgent, TrialContext
@@ -253,6 +254,11 @@ class ReSumAgent(BaseAgent):
                     try:
                         result = await ctx.session.call_tool(tc.name, tc.arguments)
                     except Exception as e:
+                        # A poisoned/terminated session can't recover — end the
+                        # trajectory cleanly rather than looping dead-session
+                        # errors for the rest of the turn budget (SDK #1780).
+                        if isinstance(e, (SessionTerminatedError, ToolFailed)):
+                            raise
                         error_output = f"ERROR: Tool call failed: {e}"
                         provider.append_tool_result(messages, tc.id, tc.name, error_output)
                         self._log_tool_result(log_file, rollout, tc.id, error_output, None, False)

--- a/firehorse/mcp/bridge.py
+++ b/firehorse/mcp/bridge.py
@@ -28,6 +28,7 @@ from openreward.api.environments.types import (
     ToolCallError,
     ToolSpec,
 )
+from openreward.api.errors import SessionTerminatedError, ToolFailed
 from firehorse.mcp.builtin_descriptions import BUILTIN_DESCRIPTIONS
 from firehorse.mcp.codex_descriptions import CODEX_DESCRIPTIONS
 from firehorse.mcp.convert import strip_bridge_markers, toolspec_to_mcp, tooloutput_to_mcp
@@ -48,6 +49,13 @@ class OpenRewardBridge:
         self._toolcalls_file: Any = None  # file handle for tool-call log
         self.tools: list[ToolSpec] = []
         self.finished = False
+        # Set once the SDK reports the underlying session is dead — a tool
+        # raised server-side (ToolFailed) or the server signalled termination
+        # (SessionTerminatedError). The SDK poisons the session on these, so
+        # every subsequent call_tool would raise SessionTerminatedError; we
+        # short-circuit instead of feeding the agent a stream of dead-session
+        # errors. See OpenReward SDK #1780 (typed errors, session poisoning).
+        self._session_terminated = False
         self.last_reward: float | None = None
         self.total_reward: float = 0.0
         self.call_count: int = 0
@@ -420,8 +428,28 @@ class OpenRewardBridge:
                 isError=True,
             )
 
+        if self._session_terminated:
+            return CallToolResult(
+                content=[TextContent(type="text", text="Session terminated. No more tool calls allowed.")],
+                isError=True,
+            )
+
         try:
             output = await self._session.call_tool(name, arguments)
+        except (SessionTerminatedError, ToolFailed) as e:
+            # The SDK has poisoned the session (a tool raised server-side, or
+            # the server terminated the session). It won't recover — mark it so
+            # subsequent calls short-circuit rather than each re-raising.
+            self._session_terminated = True
+            try:
+                with open("/tmp/firehorse_mcp_debug.log", "a") as f:
+                    f.write(f"{type(e).__name__}({name}): {e}\n")
+            except Exception:
+                pass
+            return CallToolResult(
+                content=[TextContent(type="text", text=f"Session terminated: {e}")],
+                isError=True,
+            )
         except ToolCallError as e:
             try:
                 with open("/tmp/firehorse_mcp_debug.log", "a") as f:

--- a/firehorse/trial.py
+++ b/firehorse/trial.py
@@ -7,6 +7,7 @@ import time
 from typing import Any, TYPE_CHECKING
 
 import aiohttp
+from openreward.api.errors import SessionTerminatedError, ToolFailed
 
 from firehorse.agents.base import AgentResult, TrialContext
 from firehorse.config import TrialConfig
@@ -190,6 +191,19 @@ async def run_trial(
             cost_usd=result.cost_usd,
             input_tokens=result.input_tokens,
             output_tokens=result.output_tokens,
+        )
+    except (SessionTerminatedError, ToolFailed) as e:
+        # An in-process agent (react/resum) re-raises these when the SDK
+        # poisons the session (a tool raised server-side, or the server
+        # terminated it). The session is dead; end the trial cleanly with a
+        # clearly-labelled error rather than as an opaque failure (SDK #1780).
+        duration = time.monotonic() - start
+        return TrialResult(
+            task_index=config.task_index,
+            task_spec=config.task_spec,
+            success=False,
+            error=f"session terminated: {type(e).__name__}: {e}",
+            duration_seconds=duration,
         )
     except Exception as e:
         duration = time.monotonic() - start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ authors = [
 requires-python = ">=3.11"
 
 dependencies = [
-    "openreward>=0.1.126",
+    # 0.1.127 introduced the typed error hierarchy (openreward.api.errors:
+    # ToolFailed / SessionTerminatedError) + session poisoning on tool failure,
+    # which firehorse's tool-error handling depends on.
+    "openreward>=0.1.127",
     "mcp>=1.0.0",
 ]
 

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -6,6 +6,8 @@ from unittest import mock
 
 import pytest
 
+from openreward.api.errors import SessionTerminatedError, ToolFailed
+
 from firehorse.agents.base import AgentResult
 from firehorse.trial import _is_mcp_failure, _MCP_RETRY_MAX, _MCP_RETRY_BASE_DELAY, run_trial
 from firehorse.config import TrialConfig
@@ -173,3 +175,44 @@ class TestRunTrialRetry:
         assert mock_sleep.call_count == 2
         mock_sleep.assert_any_call(2.0)
         mock_sleep.assert_any_call(4.0)
+
+
+# ---------------------------------------------------------------------------
+# Session-termination handling (SDK #1780: typed errors + session poisoning)
+# ---------------------------------------------------------------------------
+
+class TestSessionTermination:
+    @pytest.mark.asyncio
+    async def test_session_terminated_ends_trial_cleanly(self):
+        # An in-process agent re-raises SessionTerminatedError when the SDK
+        # poisons the session; run_trial should end with a clean, labelled
+        # failure rather than an opaque error or a hang.
+        env = _make_mock_env()
+        agent = mock.AsyncMock()
+        agent.run = mock.AsyncMock(
+            side_effect=SessionTerminatedError("server terminated", kind="environment")
+        )
+        config = _make_trial_config()
+        task = mock.MagicMock(task_spec={"id": "test-task"})
+
+        result = await run_trial(env, task, agent, config)
+
+        assert result.success is False
+        assert "session terminated" in result.error
+        assert "SessionTerminatedError" in result.error
+        assert agent.run.call_count == 1  # no retry against a dead session
+
+    @pytest.mark.asyncio
+    async def test_tool_failed_ends_trial_cleanly(self):
+        env = _make_mock_env()
+        agent = mock.AsyncMock()
+        agent.run = mock.AsyncMock(side_effect=ToolFailed("env tool raised"))
+        config = _make_trial_config()
+        task = mock.MagicMock(task_spec={"id": "test-task"})
+
+        result = await run_trial(env, task, agent, config)
+
+        assert result.success is False
+        assert "session terminated" in result.error
+        assert "ToolFailed" in result.error
+        assert agent.run.call_count == 1


### PR DESCRIPTION
Migrating to handling errors that were introduces in 0.1.127